### PR TITLE
feat: 색상 변수, 타이포그래피 믹스인 추가, Hashtag 컴포넌트 제작

### DIFF
--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+import { bool, oneOf } from 'prop-types';
+import { boxShadowBlack, spoqaSmallBold } from 'styles/common/common.styled';
+
+const StyledHashtag = styled.button`
+  ${boxShadowBlack}
+  ${spoqaSmallBold}
+  background-color: var(${(props) =>
+    props.isSelected ? '--color-gray1' : props.theme});
+  min-width: 5rem;
+  padding: 3px 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: 20px;
+  cursor: default;
+  transition: transform 0.3s;
+  &:hover {
+    transform: scale(1.05);
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+
+/* ---------------------------- styled components --------------------------- */
+
+export default function Hashtag({ type, isSelected = false }) {
+  let theme = '';
+
+  switch (type) {
+    case 'CSS':
+      theme = '--color-blue1';
+      break;
+    case 'JavaScript':
+      theme = '--color-yellow';
+      break;
+    case 'Algorithm':
+      theme = '--color-green1';
+      break;
+    case 'Database':
+      theme = '--color-purple';
+      break;
+    case 'Network':
+      theme = '--color-blue2';
+      break;
+    case 'Front-End':
+      theme = '--color-green2';
+      break;
+    case 'Back-End':
+      theme = '--color-orange';
+      break;
+    default:
+      break;
+  }
+  return (
+    <StyledHashtag isSelected={isSelected} theme={theme}>
+      {type}
+    </StyledHashtag>
+  );
+}
+
+/* -------------------------------- proptypes ------------------------------- */
+
+Hashtag.propTypes = {
+  type: oneOf([
+    'CSS',
+    'JavaScript',
+    'Algorithm',
+    'Database',
+    'Network',
+    'Front-End',
+    'Back-End',
+  ]),
+  isSelected: bool,
+};

--- a/client/src/components/Hashtag/Hashtag.stories.js
+++ b/client/src/components/Hashtag/Hashtag.stories.js
@@ -1,0 +1,110 @@
+import Hashtag from './Hashtag';
+
+/* -------------------------------------------------------------------------- */
+
+export default {
+  title: 'Components/Hashtag',
+  component: Hashtag,
+  parameters: {
+    docs: {
+      description: {
+        component: 'HashTag는 사용자가 선택한 관심 키워드를 나타냅니다.',
+      },
+    },
+  },
+  argTypes: {
+    type: {
+      control: 'select',
+      option: [
+        'CSS',
+        'JavaScript',
+        'Algorithm',
+        'Database',
+        'Network',
+        'Front-End',
+        'Back-End',
+      ],
+      description: '관심 키워드 지정',
+    },
+    isSelected: {
+      control: 'boolean',
+      description:
+        '관심 키워드로 선택 전 - 타입별 배경색 적용, 선택 후 - 회색 배경 적용',
+      defaultValue: false,
+    },
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+
+const Template = (args) => <Hashtag {...args} />;
+
+export const CSS = Template.bind({});
+CSS.args = {
+  type: 'CSS',
+};
+export const CSSSelected = Template.bind({});
+CSSSelected.args = {
+  type: 'CSS',
+  isSelected: true,
+};
+
+export const JavaScript = Template.bind({});
+JavaScript.args = {
+  type: 'JavaScript',
+};
+export const JavaScriptSelected = Template.bind({});
+JavaScriptSelected.args = {
+  type: 'JavaScript',
+  isSelected: true,
+};
+
+export const Algorithm = Template.bind({});
+Algorithm.args = {
+  type: 'Algorithm',
+};
+export const AlgorithmSelected = Template.bind({});
+AlgorithmSelected.args = {
+  type: 'Algorithm',
+  isSelected: true,
+};
+
+export const Database = Template.bind({});
+Database.args = {
+  type: 'Database',
+};
+export const DatabaseSelected = Template.bind({});
+DatabaseSelected.args = {
+  type: 'Database',
+  isSelected: true,
+};
+
+export const Network = Template.bind({});
+Network.args = {
+  type: 'Network',
+};
+export const NetworkSelected = Template.bind({});
+NetworkSelected.args = {
+  type: 'Network',
+  isSelected: true,
+};
+
+export const FrontEnd = Template.bind({});
+FrontEnd.args = {
+  type: 'Front-End',
+};
+export const FrontEndSelected = Template.bind({});
+FrontEndSelected.args = {
+  type: 'Front-End',
+  isSelected: true,
+};
+
+export const BackEnd = Template.bind({});
+BackEnd.args = {
+  type: 'Back-End',
+};
+export const BackEndSelected = Template.bind({});
+BackEndSelected.args = {
+  type: 'Back-End',
+  isSelected: true,
+};

--- a/client/src/styles/common/common.styled.js
+++ b/client/src/styles/common/common.styled.js
@@ -37,3 +37,35 @@ export const boxShadowWhite = css`
 export const textShadowBlack = css`
   text-shadow: 0 1px 3px #00000025;
 `;
+
+export const museoLarge = css`
+  font: 700 24px 'Museo Moderno', serif;
+`;
+
+export const museoMedium = css`
+  font: 400 18px 'Museo Moderno', serif;
+`;
+
+export const museoSmall = css`
+  font: 400 14px 'Museo Moderno', serif;
+`;
+
+export const spoqaLarge = css`
+  font: 400 20px 'Spoqa Han Sans', sans-serif;
+`;
+
+export const spoqaMedium = css`
+  font: 400 16px 'Spoqa Han Sans', sans-serif;
+`;
+
+export const spoqaMediumLight = css`
+  font: 200 16px 'Spoqa Han Sans', sans-serif;
+`;
+
+export const spoqaSmall = css`
+  font: 400 14px 'Spoqa Han Sans', sans-serif;
+`;
+
+export const spoqaSmallBold = css`
+  font: 700 14px 'Spoqa Han Sans', sans-serif;
+`;

--- a/client/src/styles/pages/theme.styled.js
+++ b/client/src/styles/pages/theme.styled.js
@@ -20,10 +20,12 @@ export const GlobalStyle = createGlobalStyle`
     --color-gray2: #AAA;
     --color-gray3: #555;
     --color-red: #DD2222;
-    --color-green: #5F885F;
+    --color-green1: #5F885F;
+    --color-green2: #6FCF97;
     --color-orange: #F2994A;
     --color-purple: #9B51E0;
-    --color-blue: #2998D4;
+    --color-blue1: #2998D4;
+    --color-blue2: #56CCF2;
     --color-yellow: #ECB312;
   }
 `;


### PR DESCRIPTION
## 개요

- closes #10 

- 색상 변수, 타이포그래피 믹스인 추가
- Hashtag 컴포넌트 설계 및 스토리북 작성


## 작업사항

- font 스타일링을 간편하게 재사용하기 위해 common.styled.js 파일에 typography 믹스인 추가
- Hashtag 작업을 위해 사용하는 색상이 늘어나서 theme.styled.js에 추가
- 관심 키워드별로 배경색과 내용을 다르게 하여 Hashtag 컴포넌트를 설계
- __prop-types__으로 컴포넌트에 전달된 값이 유요한지 검사
- __스토리북__으로 컴포넌트 테스트 및 문서 작성

## Issue

- 스토리북에서 __SCSS 색상 변수__ var(--color-name) 적용이 안되는 버그 발견. Issue에 남김.

<img width="622" alt="Screen Shot 2021-04-08 at 12 16 52 PM" src="https://user-images.githubusercontent.com/72863748/113963616-dbfeea00-9864-11eb-8a73-d72b00bb3f62.png">
<img width="426" alt="Screen Shot 2021-04-08 at 12 21 39 PM" src="https://user-images.githubusercontent.com/72863748/113963681-ff299980-9864-11eb-85b0-2c173f0db0a2.png">
<img width="612" alt="Screen Shot 2021-04-08 at 1 19 23 PM" src="https://user-images.githubusercontent.com/72863748/113968846-e0300500-986e-11eb-81c9-50f294637cee.png">
<img width="828" alt="Screen Shot 2021-04-08 at 1 18 46 PM" src="https://user-images.githubusercontent.com/72863748/113968880-ea520380-986e-11eb-9ada-c147b80440de.png">
<img width="228" alt="Screen Shot 2021-04-08 at 1 18 54 PM" src="https://user-images.githubusercontent.com/72863748/113968900-ef16b780-986e-11eb-90a8-a94c946a1af2.png">


