### PR TITLE
feat: Card 컴포넌트의 선택자, width 수정

### DIFF
--- a/client/src/components/Card/Card.js
+++ b/client/src/components/Card/Card.js
@@ -1,9 +1,9 @@
-import React from "react";
-import { bool, string, node } from "prop-types";
-import styled from "styled-components";
-import { boxShadowBlack, textShadowBlack } from "styles/common/common.styled";
-import Icon from "components/Icon/Icon";
-import Divider from "components/Divider/Divider";
+import React from 'react';
+import { bool, string, node } from 'prop-types';
+import styled from 'styled-components';
+import { boxShadowBlack, textShadowBlack } from 'styles/common/common.styled';
+import Icon from 'components/Icon/Icon';
+import Divider from 'components/Divider/Divider';
 
 /* ---------------------------- styled components ---------------------------- */
 
@@ -15,21 +15,19 @@ const CardBox = styled.div`
   background-color: var(--color-lightgray);
   padding: 1em 2em 1.4em;
 
-  svg {
+  & > svg {
     position: absolute;
+    &:first-child {
+      left: 2em;
+      top: 1em;
+    }
+    &::last-child {
+      right: 2em;
+      top: 2em;
+    }
   }
 
-  svg:first-child {
-    left: 2em;
-    top: 1em;
-  }
-
-  svg:last-of-type {
-    right: 2em;
-    top: 2em;
-  }
-
-  h2 {
+  & > h2 {
     color: var(--color-gray3);
   }
 `;
@@ -69,7 +67,6 @@ CardBox.Header = styled.div`
 `;
 
 CardBox.Content = styled.div`
-  width: 80%;
   margin: 0 auto;
 `;
 

--- a/client/src/components/Card/Card.js
+++ b/client/src/components/Card/Card.js
@@ -21,7 +21,7 @@ const CardBox = styled.div`
       left: 2em;
       top: 1em;
     }
-    &::last-child {
+    &:last-child {
       right: 2em;
       top: 2em;
     }


### PR DESCRIPTION
## 개요

- Card 컴포넌트의 후손 선택자, Content 요소의 width 수정

## 작업사항

- before : 후손 선택자 사용으로 인해 컴포넌트 내 모든 후손 svg 요소가 선택됨
- after : `& svg` 자식 선택자로 수정하여 직계 자식 요소가 아니면 영향을 받지 않도록 수정함

- 또한 불필요하게 width가 80%로 설정되어 있던 CardBox.Content 요소의 해당 코드를 삭제함
<img width="379" alt="Screen Shot 2021-04-08 at 7 40 05 PM" src="https://user-images.githubusercontent.com/72863748/114013610-ad076900-98a2-11eb-94fa-68bff5145073.png">
