### PR TITLE
feat: 프로필 페이지에 사용할 프로필 컴포넌트 제작

### DIFF
--- a/client/src/components/MiniProfile/MiniProfile.stories.js
+++ b/client/src/components/MiniProfile/MiniProfile.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        componrnt: 'MiniProfile은 QnA 답변란에 표시되는 작성자의 정보입니다.',
+        component: 'MiniProfile은 QnA 답변란에 표시되는 작성자의 정보입니다.',
       },
     },
   },

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import styled from 'styled-components';
+import { object } from 'prop-types';
+import Tier from 'components/Tier/Tier';
+import Hashtag from 'components/Hashtag/Hashtag';
+import {
+  museoLarge,
+  spoqaMediumLight,
+  spoqaSmall,
+} from 'styles/common/common.styled';
+
+const StyledProfile = styled.div`
+  display: flex;
+  position: relative;
+  padding: 16px 16px 50px;
+  max-width: 768px;
+
+  img {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    margin-right: 16px;
+    @media screen and (min-width: 480px) {
+      width: 150px;
+      height: 150px;
+    }
+  }
+  .info {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+  }
+  h2 {
+    ${museoLarge};
+    margin: 0;
+  }
+  .tierContainer {
+    display: flex;
+    align-items: center;
+    svg {
+      width: 100px;
+      height: 18px;
+      margin-right: 10px;
+    }
+    span {
+      font-size: 16px;
+    }
+  }
+  a {
+    text-decoration: none;
+    color: var(--color-gray3);
+    ${spoqaSmall}
+  }
+  p {
+    margin: 8px 0 0;
+    ${spoqaMediumLight}
+  }
+  .hashtags {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    bottom: 10px;
+    width: 100%;
+    * {
+      margin-right: 50px;
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+`;
+
+/* ---------------------------- styled components --------------------------- */
+
+export default function Profile({ user }) {
+  const { username, img, tier, hashtag, github, bio, like } = user;
+
+  return (
+    <StyledProfile>
+      <img src={img} alt={username} />
+      <div className="info">
+        <h2>{username}</h2>
+        <div className="tierContainer">
+          <Tier tier={tier} />
+          <span>{like}</span>
+        </div>
+        <a href={github}>{github}</a>
+        <p>{bio}</p>
+      </div>
+      <div className="hashtags">
+        {hashtag.map((tag) => (
+          <Hashtag type={tag} />
+        ))}
+      </div>
+    </StyledProfile>
+  );
+}
+
+/* -------------------------------- propTypes ------------------------------- */
+
+Profile.propTypes = {
+  user: object.isRequired,
+};

--- a/client/src/components/Profile/Profile.stories.js
+++ b/client/src/components/Profile/Profile.stories.js
@@ -1,0 +1,39 @@
+import Profile from './Profile';
+
+/* -------------------------------------------------------------------------- */
+
+export default {
+  title: 'Components/Profile',
+  component: Profile,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Profile은 사용자 정보를 나타나는 컴포넌트이며 프로필 페이지에 표시됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    user: {
+      description: '사용자 정보를 담은 객체',
+    },
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+
+const Template = (args) => <Profile {...args} />;
+
+export const User = Template.bind({});
+User.args = {
+  user: {
+    username: 'Frontendkid',
+    img:
+      'https://cdn.pixabay.com/photo/2021/03/25/14/00/horse-6123173_1280.jpg',
+    tier: 6,
+    github: 'https://github.com/fe-kid',
+    bio: '안녕하세요. 뛰어난 실력과 선한 인품을 가진 프론트엔드 개발자입니다.',
+    like: 20,
+    hashtag: ['CSS', 'JavaScript', 'Front-End'],
+  },
+};


### PR DESCRIPTION
## 개요

- closes #11 

- 프로필 페이지에 사용할 프로필 컴포넌트 제작


## 작업사항

- user 객체를 받아서 프로필 내용을 출력하는 Profile 컴포넌트 제작
- **prop-types**를 사용하여 props의 유효성 검사 실시
- **storybook**으로 컴포넌트 단위 테스트, 문서화
<img width="927" alt="Screen Shot 2021-04-09 at 10 17 05 PM" src="https://user-images.githubusercontent.com/72863748/114186232-8ec46a80-9981-11eb-8c12-979bd8989888.png">
