### PR TITLE
feat: 접근성을 고려한 해시태그 마크업 수정

### DIFF
--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -15,7 +15,6 @@ const StyledHashtag = styled.div`
   align-items: center;
   border: none;
   border-radius: 20px;
-  cursor: ${(props) => props.isButton && 'pointer'};
 `;
 
 /* ---------------------------- styled components --------------------------- */

--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -3,34 +3,24 @@ import styled from 'styled-components';
 import { bool, oneOf } from 'prop-types';
 import { boxShadowBlack, spoqaSmallBold } from 'styles/common/common.styled';
 
-const StyledHashtag = styled.button`
+const StyledHashtag = styled.div`
   ${boxShadowBlack}
   ${spoqaSmallBold}
   background-color: var(${(props) =>
     props.isSelected ? '--color-gray1' : props.theme});
-  min-width: 5rem;
+  width: 6rem;
   padding: 3px 10px;
   display: flex;
   justify-content: center;
   align-items: center;
   border: none;
   border-radius: 20px;
-  cursor: default;
-  transition: transform 0.3s;
-  &:hover {
-    transform: scale(1.05);
-  }
-  &:focus {
-    /* outline: none; */
-    // focus outline을 그냥 없애는 것은 접근성 위반이에요 ㅠ,ㅠ
-    // (참고: https://www.a11yproject.com/posts/2013-01-25-never-remove-css-outlines/)
-    // 딱히 버튼의 역할을 하지 않는다면 다른 요소로 마크업하시는 것 권장
-  }
+  cursor: ${(props) => props.isButton && 'pointer'};
 `;
 
 /* ---------------------------- styled components --------------------------- */
 
-export default function Hashtag({ type, isSelected = false }) {
+export default function Hashtag({ type, isSelected, isButton }) {
   let theme = '';
 
   switch (type) {
@@ -59,7 +49,12 @@ export default function Hashtag({ type, isSelected = false }) {
       break;
   }
   return (
-    <StyledHashtag isSelected={isSelected} theme={theme}>
+    <StyledHashtag
+      isSelected={isSelected}
+      theme={theme}
+      role={isButton && 'button'}
+      style={isButton ? { cursor: 'pointer' } : null}
+    >
       {type}
     </StyledHashtag>
   );
@@ -78,4 +73,5 @@ Hashtag.propTypes = {
     'Back-End',
   ]),
   isSelected: bool,
+  isButton: bool,
 };

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -8,6 +8,7 @@ import {
   spoqaMediumLight,
   spoqaSmall,
 } from 'styles/common/common.styled';
+import Icon from 'components/Icon/Icon';
 
 const StyledProfile = styled.div`
   display: flex;
@@ -37,13 +38,20 @@ const StyledProfile = styled.div`
   .tierContainer {
     display: flex;
     align-items: center;
-    svg {
+    svg:first-child {
       width: 100px;
       height: 18px;
       margin-right: 1em;
     }
+    svg:last-of-type {
+      width: 2em;
+      margin-right: 0.5em;
+      path {
+        fill: var(--color-red);
+      }
+    }
     span {
-      font-size: 1em;
+      font-size: 1.8em;
     }
   }
   a {
@@ -52,7 +60,7 @@ const StyledProfile = styled.div`
     ${spoqaSmall}
   }
   p {
-    margin: .8em 0 0;
+    margin: 0.8em 0 0;
     ${spoqaMediumLight}
   }
   .hashtags {
@@ -82,6 +90,7 @@ export default function Profile({ user }) {
         <h2>{username}</h2>
         <div className="tierContainer">
           <Tier tier={tier} />
+          <Icon type="heart-active" title="likes" />
           <span>{like}</span>
         </div>
         <a href={github}>{github}</a>


### PR DESCRIPTION
## 개요

- closes #45 

- 접근성을 고려한 해시태그 마크업 수정
- 프로필에 하트 아이콘 추가


## 작업사항

- 해시태그 컴포넌트는 때에 따라 interactive한 버튼이 되기도 하고, 그저 관심 키워드를 보여 주기 위한 용도로 쓰이기도 한다.
- 그러나 기존 해시태그 컴포넌트는 버튼으로 마크업 되어 있어, 버튼이 아닐 때에는 시맨틱하지 않은 마크업으로 접근성 이슈가 생긴다.
- 따라서 해시태그 컴포넌트를 div 요소로 마크업하고 props로 isButton 프로퍼티를 전달하여 버튼일 때 role="button"으로 버튼 역할을 부여하고 curser:pointer 스타일이 적용되도록 코드를 고쳤다.
<img width="581" alt="Screen Shot 2021-04-12 at 10 34 28 PM" src="https://user-images.githubusercontent.com/72863748/114402911-42766600-9bdf-11eb-8e54-0c8a65420a33.png">

- 프로필에 likes를 나타내는 하트 아이콘 추가
<img width="702" alt="Screen Shot 2021-04-12 at 10 55 12 PM" src="https://user-images.githubusercontent.com/72863748/114406399-799a4680-9be2-11eb-9d40-999fb62377a2.png">

