### PR TITLE
feat: 키워드 선택 컴포넌트

### DIFF
--- a/client/src/components/Dialog/Dialog.js
+++ b/client/src/components/Dialog/Dialog.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import Icon from 'components/Icon/Icon';
+import Portal from 'components/Portal/Portal';
 import { bool, string, node, oneOfType } from 'prop-types';
 
 /* ---------------------------- styled components --------------------------- */
-const DialogContainer = styled.div.attrs(props => ({
+const DialogContainer = styled.div.attrs((props) => ({
   role: 'dialog',
   ariaModal: 'true',
   ariaLable: props.label,
@@ -26,13 +27,13 @@ const DialogContainer = styled.div.attrs(props => ({
 `;
 
 const CloseButton = styled.button.attrs(() => ({
-  type: "button",
-  'aria-label': "닫기"
+  type: 'button',
+  'aria-label': '닫기',
 }))`
   position: absolute;
   top: 1em;
   right: 1em;
-  padding: .5em;
+  padding: 0.5em;
   background-color: transparent;
   border: none;
 
@@ -61,7 +62,7 @@ const Modal = styled.div.attrs(() => ({
   right: 0;
   top: 0;
   bottom: 0;
-  opacity: .3;
+  opacity: ${(props) => props.opacity};
   /* backdrop-filter: blur(20px) opacity(80%); */
 `;
 
@@ -71,6 +72,7 @@ export default function Dialog({
   infoText = '', // content of h1
   label = infoText, // aria-label
   children,
+  opacity = 0.8,
 }) {
   const dialogRef = React.useRef(null);
 
@@ -86,7 +88,7 @@ export default function Dialog({
       rootNode.setAttribute('aria-hidden', true);
       rootNode.style.userSelect = 'none';
 
-      const handleFocusTrap = e => {
+      const handleFocusTrap = (e) => {
         // 다이얼로그 노드
         // const dialogNode = dialogRef.current;
         // focusable nodes "inside" dialogNode
@@ -120,7 +122,7 @@ export default function Dialog({
         rootNode.removeAttribute('aria-hidden');
         window.removeEventListener('keydown', handleFocusTrap);
         rootNode.style.userSelect = 'auto';
-      }
+      };
     }
   }, [visible]);
 
@@ -128,25 +130,18 @@ export default function Dialog({
   // 이 컴포넌트를 Portal 컴포넌트로 감싸주세요!
   return (
     <>
-    {/* <Portal id={'dialog-container'}> */}
-      {visible ? <Modal /> : null}
-      {visible && (
-        <DialogContainer
-          ref={dialogRef}
-          label={label}
-        >
-          <CloseButton>
-            <Icon
-              type="close"
-              title="닫기"
-              height="1.8em"
-            />
-          </CloseButton>
-          <Header>{infoText}</Header>
-          {children}
-        </DialogContainer>
-      )}
-    {/* </Portal> */}
+      <Portal id={'dialog-container'}>
+        {visible ? <Modal opacity={opacity} /> : null}
+        {visible && (
+          <DialogContainer ref={dialogRef} label={label}>
+            <CloseButton>
+              <Icon type="close" title="닫기" height="1.8em" />
+            </CloseButton>
+            <Header>{infoText}</Header>
+            {children}
+          </DialogContainer>
+        )}
+      </Portal>
     </>
   );
 }

--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -19,7 +19,7 @@ const StyledHashtag = styled.div`
 
 /* ---------------------------- styled components --------------------------- */
 
-export default function Hashtag({ type, isSelected, isButton }) {
+export default function Hashtag({ type, isSelected, isButton, clicked }) {
   let theme = '';
 
   switch (type) {
@@ -49,10 +49,14 @@ export default function Hashtag({ type, isSelected, isButton }) {
   }
   return (
     <StyledHashtag
+      type={type}
       isSelected={isSelected}
       theme={theme}
       role={isButton && 'button'}
       style={isButton ? { cursor: 'pointer' } : null}
+      tabIndex={isButton ? 0 : -1}
+      onClick={clicked}
+      onKeyUp={(e) => e.code === 'Space' && clicked()}
     >
       {type}
     </StyledHashtag>

--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -1,4 +1,5 @@
 import Hashtag from 'components/Hashtag/Hashtag';
+import { array } from 'prop-types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { resetList, spoqaLarge } from 'styles/common/common.styled';
@@ -64,6 +65,8 @@ const DoneButton = styled.button`
   color: var(--color-white);
   right: 1.5em;
 `;
+
+/* ---------------------------- styled component ---------------------------- */
 
 export default function KeywordSelect({ keywordArray, userKeywords }) {
   const [selectedKeywords, setSelectedKeywords] = useState(
@@ -148,3 +151,10 @@ export default function KeywordSelect({ keywordArray, userKeywords }) {
     );
   }
 }
+
+/* ------------------------------- prop types ------------------------------- */
+
+KeywordSelect.propTypes = {
+  keywordArray: array.isRequired,
+  userKeywords: array.isRequired,
+};

--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -84,6 +84,7 @@ export default function KeywordSelect({ keywordArray, userKeywords }) {
   };
 
   const submitSelectedKeywords = () => {
+    if (selectedKeywords.length === 0) return;
     console.log('user.keyword를 selectedKeyword로 교체합니다.');
   };
 

--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -1,0 +1,149 @@
+import Hashtag from 'components/Hashtag/Hashtag';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { resetList, spoqaLarge } from 'styles/common/common.styled';
+
+const Container = styled.div`
+  button {
+    background-color: transparent;
+    border: none;
+    ${spoqaLarge}
+    position: absolute;
+    top: 1.5em;
+    z-index: 999;
+    cursor: pointer;
+  }
+`;
+const Backdrop = styled.div.attrs(() => ({
+  className: 'dim',
+  role: 'presentation',
+}))`
+  max-width: 100%;
+  z-index: 998;
+  background-color: var(--color-black);
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  opacity: ${(props) => props.opacity};
+`;
+
+const DialogContainer = styled.div.attrs((props) => ({
+  role: 'dialog',
+  ariaModal: 'true',
+  ariaLable: props.label,
+}))`
+  z-index: 999;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const StyledList = styled.ul`
+  ${resetList};
+  display: flex;
+  flex-flow: column nowrap;
+  height: 60vh;
+  justify-content: space-around;
+  li {
+    div {
+      font-size: 1.8em;
+      width: auto;
+    }
+  }
+`;
+
+const SkipButton = styled.button`
+  color: var(--color-gray2);
+  left: 1.5em;
+`;
+
+const DoneButton = styled.button`
+  color: var(--color-white);
+  right: 1.5em;
+`;
+
+export default function KeywordSelect({ keywordArray, userKeywords }) {
+  const [selectedKeywords, setSelectedKeywords] = useState(
+    userKeywords.length ? userKeywords : []
+  );
+
+  const handleClick = (keyword) => {
+    const isSelected = selectedKeywords.indexOf(keyword) > -1;
+
+    if (isSelected) {
+      // remove keyword
+      setSelectedKeywords(selectedKeywords.filter((kw) => kw !== keyword));
+    } else {
+      // add keyword
+      if (selectedKeywords.length >= 3) return;
+      setSelectedKeywords([...selectedKeywords, keyword]);
+    }
+  };
+
+  const submitSelectedKeywords = () => {
+    console.log('user.keyword를 selectedKeyword로 교체합니다.');
+  };
+
+  const skipKeywordSelect = () => {
+    setSelectedKeywords([]);
+    console.log('관심 키워드 선택을 스킵하고 창을 닫습니다.');
+  };
+
+  if (userKeywords.length) {
+    return (
+      <Container>
+        <SkipButton onClick={skipKeywordSelect}>Cancel</SkipButton>
+        <Backdrop opacity={0.8} />
+        <DialogContainer>
+          <StyledList>
+            {keywordArray.map((keyword) => {
+              return (
+                <li key={keyword.type}>
+                  <Hashtag
+                    type={keyword}
+                    isSelected={selectedKeywords.indexOf(keyword) > -1}
+                    isButton={true}
+                    clicked={() => {
+                      handleClick(keyword);
+                    }}
+                  />
+                </li>
+              );
+            })}
+          </StyledList>
+        </DialogContainer>
+        <DoneButton onClick={submitSelectedKeywords}>done</DoneButton>
+      </Container>
+    );
+  } else {
+    return (
+      <Container>
+        <SkipButton onClick={skipKeywordSelect}>Skip</SkipButton>
+        <Backdrop opacity={1} />
+        <DialogContainer>
+          <StyledList>
+            {keywordArray.map((keyword) => {
+              return (
+                <li key={keyword.type}>
+                  <Hashtag
+                    type={keyword}
+                    isSelected={selectedKeywords.indexOf(keyword) > -1}
+                    isButton={true}
+                    clicked={() => {
+                      handleClick(keyword);
+                    }}
+                  />
+                </li>
+              );
+            })}
+          </StyledList>
+        </DialogContainer>
+
+        <DoneButton onClick={submitSelectedKeywords}>Done</DoneButton>
+      </Container>
+    );
+  }
+}

--- a/client/src/components/KeywordSelect/KeywordSelect.stories.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.stories.js
@@ -1,0 +1,53 @@
+import KeywordSelect from './KeywordSelect';
+
+/* -------------------------------------------------------------------------- */
+
+export default {
+  title: 'Components/KeywordSelect',
+  component: KeywordSelect,
+  parameters: {
+    docs: {
+      description: {
+        component: '관심 키워드를 선택하는 다이얼로그 창입니다.',
+      },
+    },
+  },
+  argTypes: {
+    keywordArray: {
+      description: '선택할 수 있는 키워드 목록',
+    },
+    userKeywords: {
+      description: '사용자가 기존에 선택한 키워드 목록',
+    },
+  },
+};
+
+const Template = (args) => <KeywordSelect {...args} />;
+
+export const NoPreviousSelect = Template.bind({});
+NoPreviousSelect.args = {
+  keywordArray: [
+    'CSS',
+    'JavaScript',
+    'Algorithm',
+    'Database',
+    'Network',
+    'Front-End',
+    'Back-End',
+  ],
+  userKeywords: [],
+};
+
+export const HasUserSelected = Template.bind({});
+HasUserSelected.args = {
+  keywordArray: [
+    'CSS',
+    'JavaScript',
+    'Algorithm',
+    'Database',
+    'Network',
+    'Front-End',
+    'Back-End',
+  ],
+  userKeywords: ['CSS', 'Database'],
+};


### PR DESCRIPTION
## 개요

- closes #54 

- 키워드 선택 컴포넌트 구현


## 작업사항

- prop-types로 전달 인자 유효성 검사, storybook으로 컴포넌트 테스트 진행함
- 유저가 기존에 선택한 키워드가 있는지 여부에 따라 opacity와 버튼에 차이가 있음
- 키보드로 탐색하는 사용자를 고려하여 hashtag 컴포넌트가 버튼일 때 tabindex 부여
<img width="758" alt="Screen Shot 2021-04-13 at 4 39 43 PM" src="https://user-images.githubusercontent.com/72863748/114515387-43f36d00-9c77-11eb-9956-1804c8561b64.png">
<img width="758" alt="Screen Shot 2021-04-13 at 4 42 27 PM" src="https://user-images.githubusercontent.com/72863748/114515396-45bd3080-9c77-11eb-8a4d-e456b8cca9d4.png">

