### PR TITLE
feat: 랜덤 번역 명언 API 구현

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,6 +56,7 @@ require("./routes/authRoutes")(app);
 require("./routes/questionRoutes")(app);
 require("./routes/answerRoutes")(app);
 require("./routes/userRoutes")(app);
+require("./routes/quoteRoutes")(app);
 
 /* ----------------------------------- 서버 시작 ---------------------------------- */
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -100,6 +100,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -153,6 +161,13 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
       }
     },
     "boxen": {
@@ -224,6 +239,15 @@
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "camelcase": {
@@ -519,6 +543,13 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
       }
     },
     "fill-range": {
@@ -543,6 +574,11 @@
         "unpipe": "~1.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -558,6 +594,21 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-stream": {
       "version": "4.1.0",
@@ -606,10 +657,23 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -1027,6 +1091,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1167,9 +1236,12 @@
       }
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1344,6 +1416,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "sift": {
       "version": "7.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/minki607/Suits#readme",
   "dependencies": {
+    "axios": "^0.21.1",
     "cookie-session": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
@@ -25,7 +26,8 @@
     "mongoose": "^5.12.3",
     "nodemon": "^2.0.7",
     "passport": "^0.4.1",
-    "passport-github": "^1.1.0"
+    "passport-github": "^1.1.0",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "morgan": "^1.10.0"

--- a/server/routes/questionRoutes.js
+++ b/server/routes/questionRoutes.js
@@ -1,74 +1,75 @@
-const mongoose = require('mongoose');
-const Question = require('../model/Question');
+const mongoose = require("mongoose");
+const Question = require("../model/Question");
 const requireLogin = require("../middlewares/requireLogin");
 
 /* ------------------------------ export routes ----------------------------- */
 module.exports = (app) => {
   // 전체 questions 조회 API
-  app.get('/api/questions', async (req, res) => {
+  app.get("/api/questions", async (req, res) => {
     try {
       // find 메서드는 조건에 맞는 document들의 목록을 가져옴.
       const questions = await Question.find();
 
       res.json(questions);
-    } catch(err) {
-      res.json('Error :' + err);
+    } catch (err) {
+      res.json("Error :" + err);
     }
   });
 
   // 랜덤 questions 뽑기 API
-  app.get('/api/questions/random', async (req, res) => {
+  app.get("/api/questions/random", async (req, res) => {
     try {
       const count = await Question.countDocuments();
-      const randomNumber = Math.ceil(Math.random() * (count-1));
+      const randomNumber = Math.ceil(Math.random() * (count - 1));
       const randomQuestion = await Question.findOne().skip(randomNumber);
 
       // 또는
       // const randomQuestion = await Question.aggregate([{ $sample: { size: 1 } }]);
 
       res.json(randomQuestion);
-    } catch(err) {
-      res.json('Error :' + err);
+    } catch (err) {
+      res.json("Error :" + err);
     }
   });
 
   // Trending Question API - answers.length 값 top3인 question 가져오기
-  app.get('/api/questions/trend', async (req, res) => {
+  app.get("/api/questions/trend", async (req, res) => {
     try {
       const trendingQuestions = await Question.aggregate([
         {
-          "$project": {
-            "answers": 1,
-            "hashTag": 1,
-            "_id": 1,
-            "content": 1,
-            "postedOn": 1,
-            "length": { "$size": "$answers" }
-            }
+          $project: {
+            answers: 1,
+            hashTag: 1,
+            _id: 1,
+            content: 1,
+            postedOn: 1,
+            length: { $size: "$answers" },
+          },
         },
-        { "$sort": { "length": -1 } }, { "$limit": 3 }
+        { $sort: { length: -1 } },
+        { $limit: 3 },
       ]);
 
       res.json(trendingQuestions);
-    } catch(err) {
-      res.json('Error :' + err);
+    } catch (err) {
+      res.json("Error :" + err);
     }
   });
 
   // 전달 받은 아이디 값을 가진 question 조회
-  app.get('/api/questions/:id', async (req, res) => {
+  app.get("/api/questions/:id", async (req, res) => {
     try {
       const questionId = mongoose.Types.ObjectId(req.params.id);
       const question = await Question.findById(questionId);
 
       res.json(question);
-    } catch(err) {
-      res.json('Error :' + err);
+    } catch (err) {
+      res.json("Error :" + err);
     }
   });
 
   // answers field에 전달 받은 아이디 추가하기
-  app.patch('/api/questions/:id', async (req, res) => {
+  app.patch("/api/questions/:id", async (req, res) => {
     try {
       // const question = await Question.findByIdAndUpdate(questionId, {
       //   $push: { answers: req.body.answerId }
@@ -84,8 +85,8 @@ module.exports = (app) => {
       question.save();
 
       res.json(question);
-    } catch(err) {
-      res.json('Error :' + err);
+    } catch (err) {
+      res.json("Error :" + err);
     }
   });
 };

--- a/server/routes/quoteRoutes.js
+++ b/server/routes/quoteRoutes.js
@@ -1,0 +1,46 @@
+const axios = require("axios");
+const qs = require("qs");
+
+module.exports = (app) => {
+  app.get("/api/quote", async (req, res) => {
+    // 영문 버전의 명언들 요청
+    try {
+      const { data: quotes } = await axios.get("https://type.fit/api/quotes");
+      const randomNumber = Math.ceil(Math.random() * (quotes.length - 1));
+      const quote = quotes[randomNumber];
+      const { text, author } = quote;
+      // 요청된 명언중에서 랜덤으로 하나 지정
+
+      // 파파고 API에 전달할 파라미터 및 옵션 지정
+      const params = qs.stringify({
+        source: "en",
+        target: "ko",
+        text,
+      });
+
+      const options = {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+          "X-NCP-APIGW-API-KEY-ID": process.env.PAPAGO_CLIENT_ID,
+          "X-NCP-APIGW-API-KEY": process.env.PAPAGO_SECRET_ID,
+        },
+      };
+
+      // 파파고 API에 변역 요청
+      const response = await axios.post(
+        "https://naveropenapi.apigw.ntruss.com/nmt/v1/translation",
+        params,
+        options
+      );
+      // 변역된 text를 content, 그리고 기존의 author를 그대로 전달
+      res.send({
+        content: response.data.message.result.translatedText,
+        author,
+      });
+    } catch (err) {
+      res.status(500).send({
+        message: "명언을 불러오는데 실패하였습니다",
+      });
+    }
+  });
+};


### PR DESCRIPTION
## 개요

- closes #64 

- **GET** `/api/quote`

  **RESPONSE** `{"content":"우리의 마음과 마음을 변화시키는 열쇠는 우리의 생각과 감정이 어떻게 작용하는지에 대한 이해를 갖는 것이다.","author":"Dalai Lama"}`

  영어로된 명언을 [https://type.fit/api/quotes](https://type.fit/api/quotes) 에서 받아온뒤 랜덤으로 하나를 선택해 [네이버 파파고 NMT API](https://www.ncloud.com/product/aiService/papagoNmt)를 사용해 번역후 번역된 명언의 내용과 저자를 전달 

## 작업사항

- 랜덤 명언 API 구축시 필요한 패키지 추가 설치 (axios, [qs](https://www.npmjs.com/package/qs) 
- qs는 파파고 api에 post 요청을 보낼때 번역할 문장 + 언어 세팅을 해줘야하는데 이걸 querystring 의 형식으로 보내줘야하기 때문에 사용
```
   // 아래와 같은 기존의 객체 형식으로 보낼수 없음
    const params = {
        source: "en",
        target: "ko",       
        text,
      }
  // 따라서 아래와 같이 qs형식으로 전달
 const paramsQS = qs.stringify(params) 
 console.log(paramsQS) //source=en&target=ko&text=Nothing%20is%20at%20last%20sacred%20but%20the%20integrity%20of%20your%20own%20mind.
```
- `.env` 파일에 파파고 API 사용을 위한 **CLIENT KEY** 와 **SECRET KEY** 추가 (슬랙으로 공유)