### PR TITLE
feat: 해시태그 width 수정, 버튼 배경색과 전경색 수정

### DIFF
--- a/client/src/components/Content/QnADialog.js
+++ b/client/src/components/Content/QnADialog.js
@@ -40,7 +40,8 @@ const AnswerContainer = styled.div`
   }
 
   button {
-    background-color: var(--color-gray1);
+    background-color: var(--color-gray3);
+    color: var(--color-lightgray1);
     border: none;
     border-radius: 5px;
     width: 60px;

--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -1,14 +1,14 @@
-import React from "react";
-import styled from "styled-components";
-import { bool, oneOf } from "prop-types";
-import { boxShadowBlack, spoqaSmallBold } from "styles/common/common.styled";
+import React from 'react';
+import styled from 'styled-components';
+import { bool, oneOf } from 'prop-types';
+import { boxShadowBlack, spoqaSmallBold } from 'styles/common/common.styled';
 
 const StyledHashtag = styled.div`
   ${boxShadowBlack}
   ${spoqaSmallBold}
   background-color: var(${(props) =>
-    props.isSelected ? "--color-gray1" : props.theme});
-  width: 6rem;
+    props.isSelected ? '--color-gray1' : props.theme});
+  width: 8.4rem;
   padding: 3px 10px;
   display: flex;
   justify-content: center;
@@ -20,32 +20,32 @@ const StyledHashtag = styled.div`
 /* ---------------------------- styled components --------------------------- */
 
 export default function Hashtag({ type, isSelected, isButton, clicked }) {
-  let theme = "";
+  let theme = '';
 
   switch (type) {
-    case "All":
-      theme = "--color-lightgray2";
+    case 'All':
+      theme = '--color-lightgray2';
       break;
-    case "CSS":
-      theme = "--color-blue1";
+    case 'CSS':
+      theme = '--color-blue1';
       break;
-    case "JavaScript":
-      theme = "--color-yellow";
+    case 'JavaScript':
+      theme = '--color-yellow';
       break;
-    case "OS":
-      theme = "--color-green1";
+    case 'OS':
+      theme = '--color-green1';
       break;
-    case "Database":
-      theme = "--color-purple";
+    case 'Database':
+      theme = '--color-purple';
       break;
-    case "Network":
-      theme = "--color-blue2";
+    case 'Network':
+      theme = '--color-blue2';
       break;
-    case "Front-End":
-      theme = "--color-green2";
+    case 'Front-End':
+      theme = '--color-green2';
       break;
-    case "Back-End":
-      theme = "--color-orange";
+    case 'Back-End':
+      theme = '--color-orange';
       break;
     default:
       break;
@@ -55,11 +55,11 @@ export default function Hashtag({ type, isSelected, isButton, clicked }) {
       type={type}
       isSelected={isSelected}
       theme={theme}
-      role={isButton && "button"}
-      style={isButton ? { cursor: "pointer" } : null}
+      role={isButton && 'button'}
+      style={isButton ? { cursor: 'pointer' } : null}
       tabIndex={isButton ? 0 : -1}
       onClick={clicked}
-      onKeyUp={(e) => e.code === "Space" && clicked()}
+      onKeyUp={(e) => e.code === 'Space' && clicked()}
     >
       {type}
     </StyledHashtag>
@@ -70,14 +70,14 @@ export default function Hashtag({ type, isSelected, isButton, clicked }) {
 
 Hashtag.propTypes = {
   type: oneOf([
-    "CSS",
-    "JavaScript",
-    "OS",
-    "Database",
-    "Network",
-    "Front-End",
-    "Back-End",
-    "All",
+    'CSS',
+    'JavaScript',
+    'OS',
+    'Database',
+    'Network',
+    'Front-End',
+    'Back-End',
+    'All',
   ]),
   isSelected: bool,
   isButton: bool,


### PR DESCRIPTION
## 개요

- closes #63

- 해시태그 width 수정, 버튼 배경색과 전경색 수정


## 작업사항

- font-size를 rem으로 변환하는 작업 이후에 hashtag 컴포넌트의 레이아웃이 무너졌던 것을 width를 조절하여 해결했음.
- QnA 다이얼로그 컴포넌트 내 버튼이 부모 컴포넌트의 배경과 구분하기 쉽지 않아 접근성 이슈가 있었음.
- 버튼 배경색을 부모 컴포넌트의 배경색과 크게 차이나게 수정함으로서 접근성을 준수하게 되었음.
- https://accessible-colors.com 사이트를 참고하여 색상을 선정함.
<img width="824" alt="Screen Shot 2021-04-15 at 8 07 12 PM" src="https://user-images.githubusercontent.com/72863748/114860700-4d233c00-9e27-11eb-93fe-316a9937ab6d.png">
<img width="393" alt="Screen Shot 2021-04-15 at 8 07 35 PM" src="https://user-images.githubusercontent.com/72863748/114860702-4f859600-9e27-11eb-84b8-30bcc4341849.png">

