### PR TITLE
feat: 명언 API Response 수정

### DIFF
--- a/server/routes/quoteRoutes.js
+++ b/server/routes/quoteRoutes.js
@@ -34,8 +34,14 @@ module.exports = (app) => {
       );
       // 변역된 text를 content, 그리고 기존의 author를 그대로 전달
       res.send({
-        content: response.data.message.result.translatedText,
-        author,
+        translated: {
+          content: response.data.message.result.translatedText,
+          author,
+        },
+        original: {
+          content: text,
+          author,
+        },
       });
     } catch (err) {
       res.status(500).send({


### PR DESCRIPTION
## 개요

- closes #64  

- `/api/quote` 요청시 번역된 명언뿐만 아니라 원문도 함께 반환해 클라이언트에서 번역본,원문을 같이 볼수있도록 함

## 작업사항

- 예시) `{"translated":{"content":"기쁨의 완전한 가치를 얻기 위해서는 기쁨을 나눌 누군가가 있어야 한다.","author":"Mark Twain"},"original":{"content":"To get the full value of joy you must have someone to divide it with.","author":"Mark Twain"}}`
