### PR TITLE
feat: Icon 컴포넌트 스토리북 작성 및 proptypes 추가

### DIFF
--- a/client/src/components/Icon/Icon.js
+++ b/client/src/components/Icon/Icon.js
@@ -15,6 +15,7 @@ import { ReactComponent as QuoteRight } from "./images/quoteRight.svg";
 import { ReactComponent as Close } from "./images/close.svg";
 import { ReactComponent as Error } from "./images/error.svg";
 import { ReactComponent as Success } from "./images/success.svg";
+import { string } from "prop-types";
 
 /* -------------------------------------------------------------------------- */
 
@@ -96,4 +97,6 @@ Icon.propTypes = {
     "error",
     "success",
   ]).isRequired,
+  title: string,
+  height: string,
 };


### PR DESCRIPTION
## 개요

- closes #71 

-  누락된 아이콘 컴포넌트 스토리북 작성 및 proptype 추가


## 작업사항

- 아이콘 컴포넌트 스토리북 작성
- 누락된 proptypes (title, height) 추가

![Screen Shot 2021-04-16 at 6 10 18 pm](https://user-images.githubusercontent.com/40879385/115015393-870b4580-9eee-11eb-976f-2c32a616a812.jpg)
