### PR TITLE
feat: 좋아요 관련 API 제작

### DIFF
--- a/client/src/pages/DemoPage/DemoPage.js
+++ b/client/src/pages/DemoPage/DemoPage.js
@@ -5,12 +5,13 @@ import { useDispatch, useSelector } from "react-redux";
 import { fetchUserAction, signOutAction } from "redux/storage/auth/auth";
 import axios from "axios";
 import { useState } from "react";
+import LikeButton from "components/LikeButton/LikeButton";
 
 /* ----------------------- 테스트용 페이지 ------------------------------------- */
 export default function DemoPage() {
   const { isAuthed } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState("");
 
   useEffect(() => {
     dispatch(fetchUserAction());
@@ -34,10 +35,10 @@ export default function DemoPage() {
   const postAnswer = async () => {
     const res = await axios.post("/api/answers", {
       content,
-      questionId: '60751695af540a054f122915',
+      questionId: "607a3bf49187675cc6d6d92d",
     });
 
-    await axios.patch('/api/questions/60751695af540a054f122915', {
+    await axios.patch("/api/questions/607a3bf49187675cc6d6d92d", {
       answerId: res.data._id,
     });
 
@@ -45,7 +46,7 @@ export default function DemoPage() {
   };
 
   const patchAnswer = async () => {
-    const res = await axios.patch('/api/answers/60783162fc60153f9c61c958', {
+    const res = await axios.patch("/api/answers/60783162fc60153f9c61c958", {
       content,
     });
 
@@ -55,9 +56,21 @@ export default function DemoPage() {
   };
 
   const deleteAnswer = async () => {
-    const res = await axios.delete('/api/answers/6078303db455a302743baec0');
+    const res = await axios.delete("/api/answers/6078303db455a302743baec0");
     dispatch(fetchUserAction());
 
+    console.log(res);
+  };
+
+  const handleLike = async () => {
+    const res = await axios.put("/api/like/6078d9a9692dfa08e1606423");
+    alert("좋아요!");
+    console.log(res);
+  };
+
+  const handleUnLike = async () => {
+    const res = await axios.put("/api/unlike/6078d9a9692dfa08e1606423");
+    alert("싫어요!");
     console.log(res);
   };
 
@@ -71,14 +84,22 @@ export default function DemoPage() {
             <form onSubmit={submitHashtag}>
               <button type="submit">자바스크립트 해시태그 추가</button>
             </form>
+            <LikeButton onClick={handleLike} />
+            <LikeButton isLiked onClick={handleUnLike} />
             <form>
               <textarea
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
               />
-              <button type="button" onClick={postAnswer}>답변 등록</button>
-              <button type="button" onClick={patchAnswer}>답변 수정</button>
-              <button type="button" onClick={deleteAnswer}>답변 삭제ㅋ</button>
+              <button type="button" onClick={postAnswer}>
+                답변 등록
+              </button>
+              <button type="button" onClick={patchAnswer}>
+                답변 수정
+              </button>
+              <button type="button" onClick={deleteAnswer}>
+                답변 삭제ㅋ
+              </button>
             </form>
           </>
         ) : (

--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,8 @@ try {
 /* ------------------------------- DB 모델 불러오기 ------------------------------- */
 
 const User = require("./model/user");
+const Question = require("./model/Question");
+const Answer = require("./model/Answer");
 
 const app = express();
 app.use(express.json());
@@ -57,6 +59,7 @@ require("./routes/questionRoutes")(app);
 require("./routes/answerRoutes")(app);
 require("./routes/userRoutes")(app);
 require("./routes/quoteRoutes")(app);
+require("./routes/likeRoutes")(app);
 
 /* ----------------------------------- 서버 시작 ---------------------------------- */
 

--- a/server/model/User.js
+++ b/server/model/User.js
@@ -23,6 +23,7 @@ const userSchema = new Schema({
   hashTag: [{ type: String }],
   answeredQuestions: [{ type: Schema.Types.ObjectId, ref: "Question" }],
   memberSince: Date,
+  likeCount: { type: Number, default: 0 },
 });
 
 module.exports = mongoose.model("User", userSchema);

--- a/server/routes/answerRoutes.js
+++ b/server/routes/answerRoutes.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const Answer = require("../model/Answer");
+const Answer = mongoose.model("Answer");
 const requireLogin = require("../middlewares/requireLogin");
 
 /* ------------------------------ export routes ----------------------------- */
@@ -19,7 +19,7 @@ module.exports = (app) => {
         });
     } catch (err) {
       res.status(500).send({
-        message: err
+        message: err,
       });
     }
   });
@@ -31,18 +31,18 @@ module.exports = (app) => {
         content: req.body.content,
         postedby: req.user,
         question: mongoose.Types.ObjectId(req.body.questionId),
-        likes: []
+        likes: [],
       }).save((err, data) => {
         if (err) {
           res.status(500).send({
-            message: err
+            message: err,
           });
         }
         res.json(data);
       });
     } catch (err) {
       res.status(500).send({
-        message: err
+        message: err,
       });
     }
   });
@@ -59,7 +59,7 @@ module.exports = (app) => {
       res.json(answer);
     } catch (err) {
       res.status(500).send({
-        message: err
+        message: err,
       });
     }
   });
@@ -67,14 +67,14 @@ module.exports = (app) => {
   // delete answer and return question
   app.delete("/api/answers/:id", requireLogin, async (req, res) => {
     try {
-      const answer = await Answer.findByIdAndDelete(
-        { _id: req.params.id }
-      ).exec();
+      const answer = await Answer.findByIdAndDelete({
+        _id: req.params.id,
+      }).exec();
 
       res.json(answer);
     } catch (err) {
       res.status(500).send({
-        message: err
+        message: err,
       });
     }
   });

--- a/server/routes/likeRoutes.js
+++ b/server/routes/likeRoutes.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const requireLogin = require("../middlewares/requireLogin");
+const Question = mongoose.model("Question");
+const Answer = mongoose.model("Answer");
+const User = mongoose.model("User");
+
+module.exports = (app) => {
+  app.put("/api/like/:id", requireLogin, async (req, res) => {
+    try {
+      const answer = await Answer.findByIdAndUpdate(
+        req.params.id,
+        { $push: { likes: req.user._id } },
+        { new: true }
+      ).exec();
+      res.send(answer);
+    } catch (err) {
+      res.status(500).send({
+        message: err,
+      });
+    }
+  });
+
+  app.put("/api/unlike/:id", requireLogin, async (req, res) => {
+    try {
+      const answer = await Answer.findByIdAndUpdate(
+        req.params.id,
+        { $pull: { likes: req.user._id } },
+        { new: true }
+      ).exec();
+      res.send(answer);
+    } catch (err) {
+      res.status(500).send({
+        message: err,
+      });
+    }
+  });
+};

--- a/server/routes/likeRoutes.js
+++ b/server/routes/likeRoutes.js
@@ -1,17 +1,27 @@
 const mongoose = require("mongoose");
 const requireLogin = require("../middlewares/requireLogin");
-const Question = mongoose.model("Question");
+const updateTier = require("../utils/updateTier");
 const Answer = mongoose.model("Answer");
 const User = mongoose.model("User");
 
 module.exports = (app) => {
+  // 한번 좋아요 누른 사람은 못 누도록 처리하는건 클라이언트에서 처리
+  // 좋아요 요청시 답변의 like에 요청하는 유저의 아이디를 push (삽입)
   app.put("/api/like/:id", requireLogin, async (req, res) => {
     try {
       const answer = await Answer.findByIdAndUpdate(
         req.params.id,
         { $push: { likes: req.user._id } },
         { new: true }
-      ).exec();
+      );
+      // 유저의 누적총 좋아요 수 증가
+      const user = await User.findByIdAndUpdate(answer.postedby, {
+        $inc: { likeCount: 1 },
+      });
+
+      // 총 누적수에 따라 등급 업데이트
+      updateTier(user);
+
       res.send(answer);
     } catch (err) {
       res.status(500).send({
@@ -21,12 +31,22 @@ module.exports = (app) => {
   });
 
   app.put("/api/unlike/:id", requireLogin, async (req, res) => {
+    // 좋아요 요청시 답변의 like에 요청하는 유저의 아이디를 pull (뺌)
     try {
       const answer = await Answer.findByIdAndUpdate(
         req.params.id,
         { $pull: { likes: req.user._id } },
         { new: true }
-      ).exec();
+      );
+
+      // 유저의 누적총 좋아요 수 감소
+      await User.findByIdAndUpdate(answer.postedby, {
+        $inc: { likeCount: -1 },
+      });
+
+      // 총 누적수에 따라 등급 업데이트
+      updateTier(user);
+
       res.send(answer);
     } catch (err) {
       res.status(500).send({

--- a/server/routes/questionRoutes.js
+++ b/server/routes/questionRoutes.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const Question = require("../model/Question");
+const Question = mongoose.model("Question");
 
 /* ------------------------------ export routes ----------------------------- */
 module.exports = (app) => {

--- a/server/utils/updateTier.js
+++ b/server/utils/updateTier.js
@@ -1,0 +1,29 @@
+// 총 누적 좋아요 수가 일정량을 넘으면 주어진 조건에 따라 티어가 업데이트 되도록 설정
+const updateTier = async (user) => {
+  switch (true) {
+    case user.likeCount >= 5 && user.likeCount <= 19:
+      user.tier = 2;
+      await user.save();
+      break;
+    case user.likeCount >= 20 && user.likeCount <= 29:
+      user.tier = 3;
+      await user.save();
+      break;
+    case user.likeCount >= 30 && user.likeCount <= 49:
+      user.tier = 4;
+      await user.save();
+      break;
+    case user.likeCount >= 50 && user.likeCount <= 99:
+      user.tier = 5;
+      await user.save();
+      break;
+    case user.likeCount >= 100:
+      user.tier = 6;
+      await user.save();
+      break;
+    default:
+      break;
+  }
+};
+
+module.exports = updateTier;


### PR DESCRIPTION
## 개요

- closes #77 

- **좋아요 관련 API 제작**

   좋아요 (PUT) `api/like/:id` 
   - 좋아요 요청시 아래와 같은 작업을 함
   
   1. 좋아요 할 답변의 id와 함께 요청시 답변의 likes 필드에 좋아요를 요청한 유저의 아이디가 등록
   2. 답변자의 아이디를 검색해서 해당 유저의 누적 좋아요 수 필드를 업데이트
   3. 누적 좋아요 수에 따라서 랭크(tier) 필드를 업데이트
   
   좋아요 해체 (PUT) `api/unlike/:id`
   - 위와 반대 작업을 함
  
    

## 작업사항

- 모델은 라우트 선언 이전에 한번만 require하고 추후에 모델을 사용해야할때는 `const Answer = mongoose.model("Answer");`의 형식으로 뭉구스에 등록된 모델을 불러와 사용하도록 수정. [참고 자료](https://stackoverflow.com/questions/32322786/mongoose-model-foo-fooschema-vs-require-models-foos/32322856)
- 좋아요 관련 API를 가지고 있을 likeRoutes 생성
- User 스키마에 누적 좋아요수를 나타내기 위한 `likeCount` 필드 추가
- 유저 랭크를 업데이트 시키는 함수를  재사용할수 있도록 server ->  utils -> updateTier.js 생성
- 클라이언트 사이드에서 간단한 테스트를 위해 DemoPage 수정
