### PR TITLE
feat: Info Page 네비게이션 바 추가, dummy 컴포넌트 생성

### DIFF
--- a/client/src/components/HowToUse/HowToUse.js
+++ b/client/src/components/HowToUse/HowToUse.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function HowToUse() {
+  return <div>How To Use Component</div>;
+}

--- a/client/src/components/Icon/Icon.stories.js
+++ b/client/src/components/Icon/Icon.stories.js
@@ -1,76 +1,52 @@
-import Icon from "./Icon";
+import Icon from './Icon';
 
 /* -------------------------------------------------------------------------- */
 
 export default {
-  title: "Components/Icon",
+  title: 'Components/Icon',
   component: Icon,
   parameters: {
     docs: {
       description: {
         component:
-          "Icon 컴포넌트는 앱내에 필요한 아이콘을 지정해 사용할수 있는 컴포넌트입니다 ",
+          'Icon 컴포넌트는 앱내에 필요한 아이콘을 지정해 사용할수 있는 컴포넌트입니다 ',
       },
     },
   },
   argTypes: {
     type: {
-      description: "아이콘 타입",
-      type: "select",
+      description: '아이콘 타입',
+      type: 'select',
       options: [
-        "search",
-        "home",
-        "heart",
-        "profile",
-        "info",
-        "profile-active",
-        "info-active",
-        "heart-active",
-        "home-active",
-        "search-active",
-        "quote-left",
-        "quote-right",
-<<<<<<< HEAD
-        "close"
-      ],
-      description: "아이콘 타입을 지정",
-      defaultValue: "home",
-    },
-    title: {
-      description: "마우스 오버 시 힌트로 뜰 내용",
-      defaultValue: "아이콘",
-    },
-    height: {
-      description: "아이콘 높이",
-      defaultValue: "25px",
-=======
-        "close",
-        "error",
-        "success",
-        "github",
+        'search',
+        'home',
+        'heart',
+        'profile',
+        'info',
+        'profile-active',
+        'info-active',
+        'heart-active',
+        'home-active',
+        'search-active',
+        'quote-left',
+        'quote-right',
+        'close',
+        'error',
+        'success',
+        'github',
       ],
     },
 
     title: {
-      description: "아이콘에 마우스를 올려두면 표시될 타이틀",
+      description: '아이콘에 마우스를 올려두면 표시될 타이틀',
     },
 
     height: {
-      description: "아이콘 크기(높이)",
->>>>>>> bba5d847152c9a9e15acbf303487b46802dccca4
+      description: '아이콘 크기(높이)',
     },
   },
 };
 
-<<<<<<< HEAD
-const Template = (args) => <Icon {...args} />;
-
-export const Primary = Template.bind({});
-Primary.args = {
-  type: "home",
-  title: "아이콘",
-  height: "25px",
-=======
 /* -------------------------------------------------------------------------- */
 
 const Template = (args) => <Icon {...args} />;
@@ -78,7 +54,6 @@ const Template = (args) => <Icon {...args} />;
 export const IconVariants = Template.bind({});
 
 IconVariants.args = {
-  type: "search",
-  title: "검색",
->>>>>>> bba5d847152c9a9e15acbf303487b46802dccca4
+  type: 'search',
+  title: '검색',
 };

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function MyInfo() {
+  return <div>My Info Component</div>;
+}

--- a/client/src/components/Suits/Suits.js
+++ b/client/src/components/Suits/Suits.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Suits() {
+  return <div>Suits Component</div>;
+}

--- a/client/src/containers/InfoNav.js
+++ b/client/src/containers/InfoNav.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
+import { resetList, spoqaMediumLight } from 'styles/common/common.styled';
+import { useLocation } from 'react-router';
+
+const StyledNav = styled.ul`
+  ${resetList}
+  position: fixed;
+  top: 45px;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+`;
+
+const StyledNavLink = styled(NavLink)`
+  ${spoqaMediumLight}
+  width: 100%;
+  text-align: center;
+  padding: 1rem 0;
+  border-bottom: ${(props) =>
+    props.active ? '2px solid var(--color-gray3)' : null};
+  font-weight: ${(props) => (props.active ? 700 : 400)};
+`;
+
+export default function InfoNav() {
+  const location = useLocation();
+  const { pathname } = location;
+
+  return (
+    <StyledNav>
+      <StyledNavLink
+        to={'/info/suits'}
+        active={pathname === '/info/suits' || pathname === '/info'}
+      >
+        Suits
+      </StyledNavLink>
+      <StyledNavLink to={'/info/my-info'} active={pathname === '/info/my-info'}>
+        나의 정보
+      </StyledNavLink>
+      <StyledNavLink
+        to={'/info/how-to-use'}
+        active={pathname === '/info/how-to-use'}
+      >
+        이용 안내
+      </StyledNavLink>
+    </StyledNav>
+  );
+}

--- a/client/src/containers/Nav/Navigation.js
+++ b/client/src/containers/Nav/Navigation.js
@@ -1,8 +1,8 @@
-import React from "react";
-import Navbar from "./Navigation.styled";
-import Icon from "components/Icon/Icon";
-import useDetectViewport from "hooks/useDetectViewport";
-import { useLocation } from "react-router";
+import React from 'react';
+import Navbar from './Navigation.styled';
+import Icon from 'components/Icon/Icon';
+import useDetectViewport from 'hooks/useDetectViewport';
+import { useLocation } from 'react-router';
 
 /* -------------------------------------------------------------------------- */
 
@@ -14,19 +14,31 @@ const Navigation = () => {
   return (
     <Navbar ismobile={isMobile}>
       <Navbar.ItemLink exact to="/">
-        <Icon title="메인" type={pathname === "/" ? "home-active" : "home"} />
+        <Icon title="메인" type={pathname === '/' ? 'home-active' : 'home'} />
       </Navbar.ItemLink>
       <Navbar.ItemLink to="/search">
-        <Icon title="검색" type={pathname === "/search" ? "search-active" : "search"} />
+        <Icon
+          title="검색"
+          type={pathname === '/search' ? 'search-active' : 'search'}
+        />
       </Navbar.ItemLink>
       <Navbar.ItemLink to="/liked">
-        <Icon title="팔로잉 해시태그" type={pathname === "/liked" ? "heart-active" : "heart"} />
+        <Icon
+          title="팔로잉 해시태그"
+          type={pathname === '/liked' ? 'heart-active' : 'heart'}
+        />
       </Navbar.ItemLink>
       <Navbar.ItemLink to="/profile">
-        <Icon title="프로필" type={pathname === "/profile" ? "profile-active" : "profile"} />
+        <Icon
+          title="프로필"
+          type={pathname === '/profile' ? 'profile-active' : 'profile'}
+        />
       </Navbar.ItemLink>
       <Navbar.ItemLink to="/info">
-        <Icon title="더보기 메뉴" type={pathname === "/info" ? "info-active" : "info"} />
+        <Icon
+          title="더보기 메뉴"
+          type={pathname.includes('/info') ? 'info-active' : 'info'}
+        />
       </Navbar.ItemLink>
     </Navbar>
   );

--- a/client/src/pages/InfoPage/InfoPage.js
+++ b/client/src/pages/InfoPage/InfoPage.js
@@ -1,17 +1,26 @@
-import React from "react";
-import styled from "styled-components";
-import PageContainer from "containers/PageContainer/PageContainer.styled";
-import { pageEffect } from "styles/motions/variants";
+import React from 'react';
+import PageContainer from 'containers/PageContainer/PageContainer.styled';
+import { pageEffect } from 'styles/motions/variants';
 import TextHeaderBar from 'containers/TextHeaderBar/TextHeaderBar';
+import { Route } from 'react-router-dom';
+import InfoNav from 'containers/InfoNav';
+import Suits from 'components/Suits/Suits';
+import MyInfo from 'components/MyInfo/MyInfo';
+import HowToUse from 'components/HowToUse/HowToUse';
 
 /* -------------------------------------------------------------------------- */
 
-export default function InfoPage() {
+export default function InfoPage({ match }) {
   return (
     <>
-    <TextHeaderBar />
-    <PageContainer variants={pageEffect} initial="hidden" animate="visible">
-    </PageContainer>
+      <TextHeaderBar />
+      <PageContainer variants={pageEffect} initial="hidden" animate="visible">
+        <InfoNav />
+        <Route path={match.path} exact component={Suits} />
+        <Route path={match.path + '/suits'} component={Suits} />
+        <Route path={match.path + '/my-info'} component={MyInfo} />
+        <Route path={match.path + '/how-to-use'} component={HowToUse} />
+      </PageContainer>
     </>
-);
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
## 개요

- Info Page 네비게이션 바 추가, dummy 컴포넌트 생성


## 작업사항

- Info Page에 사용하는 네비게이션 바 구현
- route마다 컴포넌트가 잘 출력되는지 확인하기 위해 dummy 컴포넌트 생성 후 테스트
- 익일 storybook, prop-types로 테스트 진행할 예정
<img width="375" alt="Screen Shot 2021-04-19 at 10 24 47 PM" src="https://user-images.githubusercontent.com/72863748/115244085-8ed12100-a15e-11eb-9067-f5ebdb393076.png">
<img width="705" alt="Screen Shot 2021-04-19 at 10 27 02 PM" src="https://user-images.githubusercontent.com/72863748/115244089-90024e00-a15e-11eb-9e6a-4f758d8aabed.png">

