### PR TITLE
feat: My Info 페이지에 자기소개 수정, 로그아웃, 회원탈퇴 기능 추가

### DIFF
--- a/client/src/components/HowToUse/HowToUse.js
+++ b/client/src/components/HowToUse/HowToUse.js
@@ -13,6 +13,11 @@ import {
 
 const StylesHowToUse = styled.section`
   padding: 0 3em;
+  min-height: 100vh;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
   .box {
     max-width: 500px;
     margin: 0;

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -23,6 +23,7 @@ const StyledMyInfo = styled.section`
   justify-content: center;
   max-width: 568px;
   padding: 1em;
+  min-height: 100vh;
 
   .bio__container {
     display: flex;

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -1,9 +1,10 @@
-import { Skeleton } from '@material-ui/lab';
 import axios from 'axios';
 import Hashtag from 'components/Hashtag/Hashtag';
 import Icon from 'components/Icon/Icon';
 import Tier from 'components/Tier/Tier';
 import React, { useState, useEffect } from 'react';
+import { signOutAction } from 'redux/storage/auth/auth';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import {
   museoLarge,
@@ -11,7 +12,9 @@ import {
   spoqaMediumLight,
   spoqaSmall,
   spoqaSmallBold,
+  boxShadowBlack,
 } from 'styles/common/common.styled';
+import API from 'api/api';
 
 const StyledMyInfo = styled.section`
   display: flex;
@@ -49,6 +52,7 @@ const StyledMyInfo = styled.section`
       padding: 0.4em;
       height: 8em;
       letter-spacing: .5px;
+      ${boxShadowBlack};
     }
     span {
       position: absolute;
@@ -96,6 +100,7 @@ const StyledMyInfo = styled.section`
       color: var(--color-gray3);
       background-color: var(--color-lightgray2);
       border: none;
+      ${boxShadowBlack};
       }
       .delete-account {
         background-color: var(--color-gray1);
@@ -210,29 +215,11 @@ const StyledProfile = styled.div`
 `;
 
 export default function MyInfo() {
-  // 유저 더미데이터
-  // let user = {
-  //   githubId: 'boygeorge',
-  //   githubRepo: 'https://github.com/boygeorge',
-  //   avatar: 'http://www.gstatic.com/tv/thumb/persons/153450/153450_v9_bb.jpg',
-  //   username: 'George Boy',
-  //   bio:
-  //     '내가 망할 것 같애? 내가 망할 것 같애? 내가 람보르기니 조낸 많이 가지고 있는데 진짜로 망할 것 같애?',
-  //   tier: 3,
-  //   hashTag: ['CSS', 'JavaScript', 'Database'],
-  //   likeCount: 30,
-  // };
-
-  // let user = null;
-
-  // useEffect(() => {
-  //   axios.get('/api/user-profile').then((res) => {
-  //     user = res.data[0];
-  //   });
-  // }, []);
-
   const [user, setUser] = useState(null);
+  const [isBioActive, setIsBioActive] = useState(false);
   const [enteredBio, setEnteredBio] = useState('');
+
+  const dispatch = useDispatch();
 
   const getUser = async () => {
     const res = await axios.get('/api/user-profile');
@@ -253,16 +240,25 @@ export default function MyInfo() {
     console.log('changed hashtag!');
   };
 
-  const handleUpdate = () => {
-    console.log('updated!');
+  const handleClickBioButton = () => {
+    if (isBioActive) {
+      if (enteredBio === user.bio) {
+        setIsBioActive(!isBioActive);
+        return;
+      }
+
+      API('/api/user-profile/bio', 'patch', { bio: enteredBio });
+    }
+    setIsBioActive(!isBioActive);
   };
 
   const handleSignOut = () => {
-    console.log('signed out!');
+    dispatch(signOutAction());
   };
 
-  const handleDelete = () => {
-    console.log('deleted!');
+  const handleDelete = async () => {
+    await API('/api/user', 'delete');
+    dispatch(signOutAction());
   };
 
   if (user) {
@@ -283,9 +279,12 @@ export default function MyInfo() {
         <div className="bio__container">
           <div className="bio__heading-container">
             <h3>자기소개</h3>
-            <button onClick={handleUpdate}>수정</button>
+            <button onClick={handleClickBioButton}>
+              {isBioActive ? '완료' : '수정'}
+            </button>
           </div>
           <textarea
+            disabled={!isBioActive}
             id="bio"
             value={enteredBio}
             onChange={(e) => handleBioChange(e)}

--- a/client/src/components/Suits/Suits.js
+++ b/client/src/components/Suits/Suits.js
@@ -18,6 +18,7 @@ const StylesSuits = styled.section`
   justify-content: center;
   align-items: center;
   padding-top: 5em;
+  min-height: 100vh;
 
   .logo {
     width: 100px;

--- a/client/src/containers/InfoNav/InfoNav.js
+++ b/client/src/containers/InfoNav/InfoNav.js
@@ -22,7 +22,7 @@ const StyledNavLink = styled(NavLink)`
     props.active ? '2px solid var(--color-gray3)' : null};
   font-weight: ${(props) => (props.active ? 700 : 400)};
   @media screen and (min-width: 480px) {
-    font-size: 2rem;
+    font-size: 2.5rem;
   }
 `;
 
@@ -34,16 +34,19 @@ export default function InfoNav() {
     <StyledNav>
       <StyledNavLink
         to={'/info/suits'}
-        active={pathname === '/info/suits' || pathname === '/info'}
+        active={pathname === '/info/suits' || pathname === '/info' ? 1 : 0}
       >
         Suits
       </StyledNavLink>
-      <StyledNavLink to={'/info/my-info'} active={pathname === '/info/my-info'}>
+      <StyledNavLink
+        to={'/info/my-info'}
+        active={pathname === '/info/my-info' ? 1 : 0}
+      >
         나의 정보
       </StyledNavLink>
       <StyledNavLink
         to={'/info/how-to-use'}
-        active={pathname === '/info/how-to-use'}
+        active={pathname === '/info/how-to-use' ? 1 : 0}
       >
         이용 안내
       </StyledNavLink>

--- a/client/src/redux/storage/auth/auth.js
+++ b/client/src/redux/storage/auth/auth.js
@@ -1,17 +1,17 @@
-import axios from "axios";
+import axios from 'axios';
 
-const FETCH_USER = "유저 정보 요청";
-const FETCH_USER_SUCCESS = "유저 정보 요청 성공";
-const FETCH_USER_FAILURE = "유저 정보 요청 실패";
+const FETCH_USER = '유저 정보 요청';
+const FETCH_USER_SUCCESS = '유저 정보 요청 성공';
+const FETCH_USER_FAILURE = '유저 정보 요청 실패';
 
-const SIGN_OUT = "로그아웃 요청";
-const SIGN_OUT_SUCCESS = "로그아웃 요청 성공";
-const SIGN_OUT_FAILURE = "로그아웃 요청 실패";
+const SIGN_OUT = '로그아웃 요청';
+const SIGN_OUT_SUCCESS = '로그아웃 요청 성공';
+const SIGN_OUT_FAILURE = '로그아웃 요청 실패';
 
 export const fetchUserAction = () => async (dispatch) => {
   dispatch({ type: FETCH_USER });
   try {
-    const res = await axios.get("/auth/user");
+    const res = await axios.get('/auth/user');
     dispatch({ type: FETCH_USER_SUCCESS, authUser: res.data.user });
   } catch (err) {
     dispatch({ type: FETCH_USER_FAILURE, msg: err.response.data });
@@ -21,7 +21,7 @@ export const fetchUserAction = () => async (dispatch) => {
 export const signOutAction = () => async (dispatch) => {
   dispatch({ type: SIGN_OUT });
   try {
-    const res = await axios.get("auth/logout");
+    const res = await axios.get('/auth/logout');
     dispatch({ type: SIGN_OUT_SUCCESS });
   } catch (err) {
     dispatch({ type: SIGN_OUT_FAILURE, msg: err.response.data });

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,19 +1,19 @@
-const passport = require("passport");
+const passport = require('passport');
 
 module.exports = (app) => {
-  app.get("/auth/github", passport.authenticate("github"));
+  app.get('/auth/github', passport.authenticate('github'));
   app.get(
-    "/auth/github/callback",
-    passport.authenticate("github", {
-      failureRedirect: "http://localhost:3000/login",
-      successRedirect: "http://localhost:3000/login",
+    '/auth/github/callback',
+    passport.authenticate('github', {
+      failureRedirect: 'http://localhost:3000/login',
+      successRedirect: 'http://localhost:3000/login',
     }),
     function (req, res) {
       res.sendStatus(200);
     }
   );
 
-  app.get("/auth/user", (req, res) => {
+  app.get('/auth/user', (req, res) => {
     if (req.user) {
       res.send({ user: req.user });
     } else {
@@ -21,13 +21,14 @@ module.exports = (app) => {
     }
   });
 
-  app.get("/auth/logout", (req, res) => {
+  app.get('/auth/logout', (req, res) => {
     if (req.user) {
       req.logout();
-      res.redirect("http://localhost:3000/login");
+      // res.redirect("http://localhost:3000/login");
+      res.redirect('/');
     } else {
       res.send({
-        message: "로그아웃할 유저 정보를 찾을 수 없습니다",
+        message: '로그아웃할 유저 정보를 찾을 수 없습니다',
       });
     }
   });

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,18 +1,18 @@
-const mongoose = require("mongoose");
-const requireLogin = require("../middlewares/requireLogin");
-const User = mongoose.model("User");
+const mongoose = require('mongoose');
+const requireLogin = require('../middlewares/requireLogin');
+const User = mongoose.model('User');
 
 module.exports = (app) => {
   /* --------------------------------- 프로필 조회 --------------------------------- */
 
-  app.get("/api/user-profile", requireLogin, async (req, res) => {
+  app.get('/api/user-profile', requireLogin, async (req, res) => {
     if (req.user) {
       await User.find({ _id: req.user._id })
         .populate({
-          path: "answeredQuestions",
+          path: 'answeredQuestions',
           populate: {
-            path: "answers",
-            populate: "postedby",
+            path: 'answers',
+            populate: 'postedby',
           },
         })
         .exec((err, data) => {
@@ -32,11 +32,11 @@ module.exports = (app) => {
   /* --------------------------------- 회원정보 수정 -------------------------------- */
 
   // 해시태그 추가,수정
-  app.patch("/api/user-profile/hashtag", requireLogin, async (req, res) => {
+  app.patch('/api/user-profile/hashtag', requireLogin, async (req, res) => {
     try {
       req.user.hashTag = req.body.hashTag;
       await req.user.save();
-      res.status(200).send({ message: "성공적으로 저장" });
+      res.status(200).send({ message: '성공적으로 저장' });
     } catch (err) {
       res.status(500).send({
         message: err,
@@ -45,11 +45,11 @@ module.exports = (app) => {
   });
 
   // Bio 수정
-  app.patch("api/user-profile/bio", requireLogin, async (req, res) => {
+  app.patch('/api/user-profile/bio', requireLogin, async (req, res) => {
     try {
       req.user.bio = req.body.bio;
       await req.user.save();
-      res.status(200).send({ message: "성공적으로 저장" });
+      res.status(200).send({ message: '성공적으로 저장' });
     } catch (err) {
       res.status(500).send({
         message: err,
@@ -58,7 +58,7 @@ module.exports = (app) => {
   });
 
   // 회원탈퇴
-  app.delete("/api/user", requireLogin, (req, res) => {
+  app.delete('/api/user', requireLogin, (req, res) => {
     User.findOneAndRemove({ _id: req.user._id }, (err) => {
       if (err) {
         res.status(500).send({
@@ -67,13 +67,13 @@ module.exports = (app) => {
       }
       req.logout();
       res.status(200).send({
-        message: "성공적으로 삭제",
+        message: '성공적으로 삭제',
       });
     });
   });
 
   // hard workers 정보 조회
-  app.get("/api/hard-workers", requireLogin, async (req, res) => {
+  app.get('/api/hard-workers', requireLogin, async (req, res) => {
     try {
       const hardWorkers = await User.aggregate([
         {
@@ -101,7 +101,7 @@ module.exports = (app) => {
   });
 
   // 타 유저 프로필을 아이디로 조회. 불필요한 정보는 반환하지않음
-  app.get("/api/user-profile/:id", requireLogin, async (req, res) => {
+  app.get('/api/user-profile/:id', requireLogin, async (req, res) => {
     try {
       const user = await User.find(
         {


### PR DESCRIPTION
## 개요

- My Info 페이지에 자기소개 수정, 로그아웃, 회원탈퇴 기능 추가


## 작업사항

- 자기소개 수정 버튼 클릭시 textarea 활성화, 텍스트 수정 후 완료 버튼 클릭시 user의 bio 데이터 patch하고 textarea 비활성화
- 로그아웃, 회원탈퇴시 login 페이지로 redirect
- 로딩시 스켈레톤 UI, 회원탈퇴시 confirm dialog 구현 필요
<img width="387" alt="Screen Shot 2021-04-21 at 6 31 40 PM" src="https://user-images.githubusercontent.com/72863748/115531597-ed69dc80-a2cf-11eb-8763-7372f1284bd7.png">
