### PR TITLE
feat: info page 레이아웃 붕괴 해결, my-info 로딩 메시지 추가

### DIFF
--- a/client/src/components/Content/HardWorkersContent.js
+++ b/client/src/components/Content/HardWorkersContent.js
@@ -1,9 +1,9 @@
-import HardWorker from "components/HardWorker/HardWorker";
-import React from "react";
-import styled from "styled-components";
-import { resetList } from "styles/common/common.styled";
-import { array, bool } from "prop-types";
-import { Skeleton } from "@material-ui/lab";
+import HardWorker from 'components/HardWorker/HardWorker';
+import React from 'react';
+import styled from 'styled-components';
+import { resetList } from 'styles/common/common.styled';
+import { array, bool } from 'prop-types';
+import { Skeleton } from '@material-ui/lab';
 
 const HardWorkers = styled.ul`
   ${resetList}

--- a/client/src/components/HardWorker/HardWorker.js
+++ b/client/src/components/HardWorker/HardWorker.js
@@ -1,18 +1,18 @@
-import React from "react";
-import styled from "styled-components";
-import { museoSmall, textShadowBlack } from "styles/common/common.styled";
-import { string, number } from "prop-types";
-import Tier from "components/Tier/Tier";
+import React from 'react';
+import styled from 'styled-components';
+import { museoSmall, textShadowBlack } from 'styles/common/common.styled';
+import { string, number } from 'prop-types';
+import Tier from 'components/Tier/Tier';
 
 const StyledHardWorker = styled.div`
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
-  width: 25%;
 
   svg {
     height: 10px;
+    max-width: 80px;
     @media screen and (min-width: 480px) {
       height: 15px;
     }
@@ -32,8 +32,8 @@ StyledHardWorker.Image = styled.div`
   border-radius: 50%;
 
   @media screen and (min-width: 480px) {
-    width: 130px;
-    height: 130px;
+    width: 120px;
+    height: 120px;
   }
 
   @media screen and (min-width: 768px) {
@@ -59,12 +59,12 @@ StyledHardWorker.Username = styled.h3`
 
 export default function HardWorker({
   id,
-  img = "https://cdn.pixabay.com/photo/2021/03/25/14/00/horse-6123173_1280.jpg",
-  username = "username",
+  img = 'https://cdn.pixabay.com/photo/2021/03/25/14/00/horse-6123173_1280.jpg',
+  username = 'username',
   tier = 1,
 }) {
   const goToProfile = (id) => {
-    console.log(id + "을 아이디로 가진 유저의 프로필 페이지로 이동");
+    console.log(id + '을 아이디로 가진 유저의 프로필 페이지로 이동');
   };
 
   return (

--- a/client/src/components/HowToUse/HowToUse.js
+++ b/client/src/components/HowToUse/HowToUse.js
@@ -6,24 +6,20 @@ import styled from 'styled-components';
 import {
   museoLarge,
   museoMedium,
+  resetList,
   spoqaLarge,
   spoqaMedium,
   spoqaMediumLight,
 } from 'styles/common/common.styled';
 
 const StylesHowToUse = styled.section`
-  padding: 0 3em;
-  min-height: 100vh;
+  padding: 0 2em;
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  justify-content: center;
+  margin-top: 120px;
   .box {
     max-width: 500px;
-    margin: 0;
-    &:first-child {
-      margin-bottom: 2em;
-    }
     h2 {
       ${spoqaMedium}
       text-align: center;
@@ -32,13 +28,26 @@ const StylesHowToUse = styled.section`
   }
 
   .box-feature {
-    p {
-      ${spoqaMediumLight}
-      margin: 0;
+    margin-bottom: 2em;
+    ul {
+      ${resetList}
+      display: flex;
+      flex-flow: column nowrap;
+      li {
+        display: flex;
+        margin-bottom: 0.2em;
+      }
+
+      span {
+        ${spoqaMediumLight}
+        margin: 0 0 0 0.4em;
+        flex: 1;
+      }
     }
   }
 
   .box-tier {
+    margin: 0;
     .tiers__container {
       display: flex;
       flex-flow: column nowrap;
@@ -66,17 +75,23 @@ const StylesHowToUse = styled.section`
   }
   @media screen and (max-height: 667px) {
     .box-feature {
-      p {
-        svg {
-          width: 20px;
-          height: 20px;
+      margin-bottom: 0.6em;
+      ul {
+        li {
+          svg {
+            width: 20px;
+            height: 20px;
+          }
+          span {
+            font-size: 1.5rem;
+          }
         }
-        font-size: 1.4rem;
       }
     }
   }
 
   @media screen and (min-width: 480px) {
+    margin-top: 160px;
     .box {
       &:first-child {
         margin-bottom: 4em;
@@ -126,18 +141,34 @@ export default function HowToUse() {
       <div className="box box-feature">
         <h2>주요 기능 소개</h2>
         <Divider width="40%" margin="0.5em auto" />
-        <p>
-          <Icon type="home" /> 랜덤 면접 질문, 랜덤 명언, 좋아요를 가장 많이
-          받은 사용자, 답변이 가장 많이 달린 면접 질문을 볼 수 있습니다. <br />
-          <Icon type="search" /> 원하는 키워드로 면접 질문을 검색할 수 있습니다.
-          <br />
-          <Icon type="heart" /> 설정한 관심 키워드에 맞는 면접 질문들을 둘러볼
-          수 있습니다. <br />
-          <Icon type="profile" /> 나의 프로필과 내가 작성한 답변을 확인할 수
-          있습니다. <br />
-          <Icon type="info" /> 서비스 소개, 나의 정보, 이용 안내를 볼 수
-          있습니다. <br />
-        </p>
+        <ul>
+          <li>
+            <Icon type="home" />
+            <span>
+              랜덤 면접 질문, 랜덤 명언, 좋아요를 가장 많이 받은 사용자, 답변이
+              가장 많이 달린 면접 질문을 볼 수 있습니다.
+            </span>
+          </li>
+          <li>
+            <Icon type="search" />
+            <span>원하는 키워드로 면접 질문을 검색할 수 있습니다.</span>
+          </li>
+          <li>
+            <Icon type="heart" />
+            <span>
+              설정한 관심 키워드에 맞는 면접 질문들을 둘러볼 수 있습니다.
+            </span>
+          </li>
+          <li>
+            <Icon type="profile" />
+            <span>나의 프로필과 내가 작성한 답변을 확인할 수 있습니다.</span>
+          </li>
+          <li>
+            {' '}
+            <Icon type="info" />
+            <span>서비스 소개, 나의 정보, 이용 안내를 볼 수 있습니다.</span>
+          </li>
+        </ul>
       </div>
       <div className="box box-tier">
         <h2>회원 등급</h2>

--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -101,6 +101,10 @@ export default function KeywordSelect({ userKeywords, onDone, onCancel }) {
   };
 
   const submitSelectedKeywords = () => {
+    if (userKeywords === selectedKeywords) {
+      onCancel();
+      return;
+    }
     onDone(selectedKeywords);
   };
 
@@ -120,7 +124,7 @@ export default function KeywordSelect({ userKeywords, onDone, onCancel }) {
               <li key={keyword}>
                 <Hashtag
                   type={keyword}
-                  isSelected={selectedKeywords.indexOf(keyword) > -1}
+                  isSelected={selectedKeywords.indexOf(keyword) === -1}
                   isButton={true}
                   clicked={() => {
                     handleClick(keyword);

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -23,10 +23,9 @@ const StyledMyInfo = styled.section`
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  justify-content: center;
   max-width: 568px;
   padding: 1em;
-  min-height: 100vh;
+  margin-top: 130px;
 
   .bio__container {
     display: flex;
@@ -55,8 +54,11 @@ const StyledMyInfo = styled.section`
       font-size: 1.4rem;
       padding: 0.4em;
       height: 8em;
-      letter-spacing: .5px;
+      letter-spacing: 0.5px;
       ${boxShadowBlack};
+      &:disabled {
+        background-color: var(--color-lightgray2);
+      }
     }
     span {
       position: absolute;
@@ -100,26 +102,23 @@ const StyledMyInfo = styled.section`
     button {
       padding: 0.5em;
       ${spoqaMedium}
-      margin-bottom: 1em;
-      color: var(--color-gray3);
-      background-color: var(--color-lightgray2);
       border: none;
       ${boxShadowBlack};
-      }
-      .delete-account {
-        background-color: var(--color-gray1);
-        color: var(--color-red);
-      }
     }
-    .update {
-      border: 2px solid var(--color-gray1);
-      background-color: transparent;
+    .signout {
+      color: var(--color-gray3);
+      background-color: var(--color-lightgray2);
+      margin-bottom: 1em;
     }
     .delete-account {
+      background-color: var(--color-gray1);
       color: var(--color-red);
     }
   }
+
   @media screen and (min-width: 480px) {
+    margin-top: 160px;
+
     .bio__container {
       .bio__heading-container {
         h3 {
@@ -133,6 +132,7 @@ const StyledMyInfo = styled.section`
         font-size: 2rem;
       }
     }
+
     .hashtag__container {
       .hashtag__heading-container {
         h3 {
@@ -146,18 +146,23 @@ const StyledMyInfo = styled.section`
         justify-content: center;
         * {
           font-size: 2rem;
-          width: 140px;
+          width: 160px;
           &:not(:last-child) {
             margin-right: 3rem;
           }
         }
       }
     }
+
     .button__container {
       button {
         font-size: 2rem;
       }
     }
+  }
+
+  @media screen and (max-height: 667px) {
+    margin-top: 100px;
   }
 `;
 
@@ -388,7 +393,7 @@ export default function MyInfo() {
               onChange={(e) => handleBioChange(e)}
               maxLength="119"
             />
-            <span>{enteredBio.length}/120</span>
+            {isBioActive && <span>{enteredBio.length}/120</span>}
           </div>
           <div className="hashtag__container">
             <div className="hashtag__heading-container">

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -402,7 +402,7 @@ export default function MyInfo() {
             </div>
             <div className="hashtag__hashtags">
               {user.hashTag.map((ht) => {
-                return <Hashtag key={ht} type={ht} isSelected={true} />;
+                return <Hashtag key={ht} type={ht} />;
               })}
             </div>
           </div>

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -13,11 +13,14 @@ import {
   spoqaSmall,
   spoqaSmallBold,
   boxShadowBlack,
+  resetBoxModel,
 } from 'styles/common/common.styled';
 import API from 'api/api';
 import { confirmAlert } from 'react-confirm-alert';
 import 'react-confirm-alert/src/react-confirm-alert.css';
 import KeywordSelect from 'components/KeywordSelect/KeywordSelect';
+
+/* -------------------------------------------------------------------------- */
 
 const StyledMyInfo = styled.section`
   display: flex;
@@ -272,6 +275,18 @@ const StyledConfirmAlert = styled.div`
   }
 `;
 
+const Loading = styled.p`
+  ${resetBoxModel};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  font-size: 3rem;
+`;
+
+/* ---------------------------- styled components --------------------------- */
+
 export default function MyInfo() {
   const [user, setUser] = useState(null);
   const [isBioActive, setIsBioActive] = useState(false);
@@ -419,5 +434,5 @@ export default function MyInfo() {
     );
   }
 
-  return <p>스켈레톤</p>;
+  return <Loading>Loading...</Loading>;
 }

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -100,9 +100,7 @@ export default function Profile({ user }) {
       </div>
       <div className="hashtags">
         {hashtag.length !== 0 ? (
-          hashtag.map((tag) => (
-            <Hashtag key={tag} type={tag} isSelected={true} />
-          ))
+          hashtag.map((tag) => <Hashtag key={tag} type={tag} />)
         ) : (
           <Link to="/info/my-info">관심 태그 등록</Link>
         )}

--- a/client/src/components/Suits/Suits.js
+++ b/client/src/components/Suits/Suits.js
@@ -15,11 +15,8 @@ import Icon from 'components/Icon/Icon';
 const StylesSuits = styled.section`
   display: flex;
   flex-flow: column nowrap;
-  justify-content: center;
   align-items: center;
-  padding-top: 5em;
-  min-height: 100vh;
-
+  margin-top: 120px;
   .logo {
     width: 100px;
     display: block;
@@ -83,6 +80,7 @@ const StylesSuits = styled.section`
   }
 
   @media screen and (min-width: 480px) {
+    margin-top: 160px;
     .logo {
       width: 150px;
       margin-bottom: 3em;

--- a/client/src/containers/InfoNav/InfoNav.js
+++ b/client/src/containers/InfoNav/InfoNav.js
@@ -11,6 +11,7 @@ const StyledNav = styled.ul`
   width: 100%;
   display: flex;
   justify-content: space-around;
+  background-color: var(--color-white);
 `;
 
 const StyledNavLink = styled(NavLink)`


### PR DESCRIPTION
## 개요

- info page 레이아웃 붕괴 해결, my-info 로딩 메시지 추가


## 작업사항

- info page의 min-height로 인해 레이아웃이 망가지던 문제 해결
- my-info에서 유저 데이터를 불러들이는 동안 표시될 로딩 메시지 추가
- 오래 걸리지 않아 지루할 틈이 없으므로 간단히 'Loading...' 메시지 사용
<img width="409" alt="Screen Shot 2021-04-22 at 10 42 45 AM" src="https://user-images.githubusercontent.com/72863748/115643444-bd661c00-a357-11eb-8aed-f52072ce3872.png">
