### PR TITLE
feat: 카드컴포넌트에 tags 속성 추가

### DIFF
--- a/client/src/components/Card/Card.js
+++ b/client/src/components/Card/Card.js
@@ -66,8 +66,8 @@ export default function Card({
           {tags && (
             <TagList>
               {tags.map((tag, idx) => (
-                <li>
-                  <Hashtag key={idx} type={tag} />
+                <li key={idx}>
+                  <Hashtag type={tag} />
                 </li>
               ))}
             </TagList>

--- a/client/src/components/Card/Card.js
+++ b/client/src/components/Card/Card.js
@@ -1,16 +1,22 @@
 import React from "react";
 import { bool, string, node } from "prop-types";
 import styled, { css } from "styled-components";
-import { boxShadowBlack, textShadowBlack } from "styles/common/common.styled";
+import {
+  boxShadowBlack,
+  resetList,
+  textShadowBlack,
+} from "styles/common/common.styled";
 import Icon from "components/Icon/Icon";
 import Divider from "components/Divider/Divider";
-import { Skeleton } from "@material-ui/lab";
+import Hashtag from "components/Hashtag/Hashtag";
+import { array } from "prop-types";
 
 /* ---------------------------- styled components ---------------------------- */
 
 const CardBox = styled.div`
   ${boxShadowBlack}
-  cursor: ${(props) => (props.isQuestion && !props.isDialog ? 'pointer' : 'initial')};
+  cursor: ${(props) =>
+    props.isQuestion && !props.isDialog ? "pointer" : "initial"};
   position: relative;
   min-width: 305px;
   border-radius: 10px;
@@ -23,12 +29,16 @@ const CardBox = styled.div`
   width: 100%;
 `;
 
-const SkeletonTitle = styled(Skeleton)`
-  padding: 0 3em !important;
-  margin-bottom: 1.3em !important;
-  max-width: 500px;
+const TagList = styled.ul`
+  ${resetList};
+  display: flex;
+  justify-content: space-between;
+  max-width: 300px;
   margin: 0 auto;
-  height: 1.6em;
+  margin-top: 1em;
+  li {
+    margin: 0 auto;
+  }
 `;
 /* -------------------------------------------------------------------------- */
 
@@ -36,6 +46,7 @@ export default function Card({
   isQuestion,
   isDialog,
   title,
+  tags,
   onClick,
   children,
   ...restProps
@@ -52,6 +63,15 @@ export default function Card({
     >
       {title && (
         <>
+          {tags && (
+            <TagList>
+              {tags.map((tag, idx) => (
+                <li>
+                  <Hashtag key={idx} type={tag} />
+                </li>
+              ))}
+            </TagList>
+          )}
           <CardBox.Header>
             {isQuestion && (
               <>
@@ -85,11 +105,9 @@ CardBox.Header = styled.div`
     position: absolute;
     &:first-child {
       left: 2em;
-      top: 1em;
     }
     &:nth-child(2) {
       right: 2em;
-      top: 2em;
     }
   }
 `;
@@ -102,6 +120,8 @@ CardBox.Content = styled.div`
 
 Card.propTypes = {
   isQuestion: bool,
+  isDialog: bool,
+  tags: array,
   title: string,
   children: node,
 };

--- a/client/src/components/Card/Card.stories.js
+++ b/client/src/components/Card/Card.stories.js
@@ -1,33 +1,39 @@
-import Card from './Card';
-import { QuoteContent } from '../Content/QuotesContent.stories';
-import { TrendingQnAContent } from '../Content/TrendingQuestionContent.stories';
-import { QNAContent } from '../Content/QnAContent.stories';
-import { HardWorkers } from 'components/Content/HardWorkersContent.stories';
+import Card from "./Card";
+import { QuoteContent } from "../Content/QuotesContent.stories";
+import { TrendingQnAContent } from "../Content/TrendingQuestionContent.stories";
+import { QNAContent } from "../Content/QnAContent.stories";
+import { HardWorkers } from "components/Content/HardWorkersContent.stories";
 
 /* -------------------------------------------------------------------------- */
 
 export default {
-  title: 'Components/Card',
+  title: "Components/Card",
   component: Card,
 
   parameters: {
     docs: {
       description: {
-        component: '카드 컴포넌트는 컨텐츠를 담는 컨테이너입니다.',
+        component: "카드 컴포넌트는 컨텐츠를 담는 컨테이너입니다.",
       },
     },
   },
   argTypes: {
     isQuestion: {
-      control: 'boolean',
-      description: 'Q&A 카드 여부를 나타냄.',
+      control: "boolean",
+      description: "Q&A 카드 여부를 나타냄.",
       defaultValue: false,
     },
     title: {
-      description: '컨텐츠 제목을 나타냄.',
+      description: "컨텐츠 제목을 나타냄.",
+    },
+    isDialog: {
+      description: "카드가 다이얼로그로 쓰일껀지에 대한 여부",
+    },
+    tags: {
+      description: "카드에 명시될 태그를 보여주기 위한 용도",
     },
     children: {
-      description: '카드의 컨텐츠',
+      description: "카드의 컨텐츠",
     },
   },
 };
@@ -42,29 +48,29 @@ export const PrimaryHardWorkersCard = Template.bind({});
 
 PrimaryCard.args = {
   isQuestion: false,
-  title: '제목',
+  title: "제목",
 };
 
 PrimaryQuoteCard.args = {
   isQuestion: false,
-  title: 'Wisdom of the day',
+  title: "Wisdom of the day",
   children: <QuoteContent {...QuoteContent.args} />,
 };
 
 PrimaryTrendingQNACard.args = {
   isQuestion: false,
-  title: 'Trending QnA',
+  title: "Trending QnA",
   children: <TrendingQnAContent />,
 };
 
 PrimaryQNACard.args = {
   isQuestion: true,
-  title: '객체 리터럴 생성 방식에 대해 설명해보시오',
+  title: "객체 리터럴 생성 방식에 대해 설명해보시오",
   children: <QNAContent {...QNAContent.args} />,
 };
 
 PrimaryHardWorkersCard.args = {
   isQuestion: true,
-  title: 'Hard Workers',
+  title: "Hard Workers",
   children: <HardWorkers {...HardWorkers.args} />,
 };

--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import styled, { css } from 'styled-components';
-import { bool, oneOf } from 'prop-types';
-import { boxShadowBlack, spoqaSmallBold } from 'styles/common/common.styled';
+import React from "react";
+import styled, { css } from "styled-components";
+import { bool, oneOf } from "prop-types";
+import { boxShadowBlack, spoqaSmallBold } from "styles/common/common.styled";
 
 const StyledHashtag = styled.div`
   ${boxShadowBlack}
@@ -13,49 +13,49 @@ const StyledHashtag = styled.div`
   border: none;
   border-radius: 3em;
   min-width: 7.6rem;
-  font-size: ${(props) => (props.isSelected ? 'inherit' : '1rem')};
+  font-size: ${(props) => (props.isSelected ? "inherit" : "1rem")};
   background-color: ${(props) =>
-    !props.isSelected ? `var(${props.theme})` : 'var(--color-gray1)'};
+    !props.isSelected ? `var(${props.theme})` : "var(--color-gray1)"};
   color: ${(props) =>
-    !props.isSelected ? 'var(--color-black)' : 'var(--color-gray3)'};
+    !props.isSelected ? "var(--color-black)" : "var(--color-gray3)"};
 
-${({ type }) =>
-    type === 'All' &&
+  ${({ type }) =>
+    type === "All" &&
     css`
-      color:
-        ${(props) => props.isSelected ? 'var(--color-black)' : 'var(--color-white)' };
+      color: ${(props) =>
+        props.isSelected ? "var(--color-black)" : "var(--color-white)"};
     `}
 `;
 
 /* ---------------------------- styled components --------------------------- */
 
 export default function Hashtag({ type, isSelected, isButton, clicked }) {
-  let theme = '';
+  let theme = "";
 
   switch (type) {
-    case 'All':
-      theme = '--color-black';
+    case "All":
+      theme = "--color-black";
       break;
-    case 'CSS':
-      theme = '--color-blue1';
+    case "CSS":
+      theme = "--color-blue1";
       break;
-    case 'JavaScript':
-      theme = '--color-yellow';
+    case "JavaScript":
+      theme = "--color-yellow";
       break;
-    case 'OS':
-      theme = '--color-green1';
+    case "OS":
+      theme = "--color-green1";
       break;
-    case 'Database':
-      theme = '--color-purple';
+    case "Database":
+      theme = "--color-purple";
       break;
-    case 'Network':
-      theme = '--color-blue2';
+    case "Network":
+      theme = "--color-blue2";
       break;
-    case 'Front-End':
-      theme = '--color-green2';
+    case "Front-End":
+      theme = "--color-green2";
       break;
-    case 'Back-End':
-      theme = '--color-orange';
+    case "Back-End":
+      theme = "--color-orange";
       break;
     default:
       break;
@@ -65,11 +65,11 @@ export default function Hashtag({ type, isSelected, isButton, clicked }) {
       type={type}
       isSelected={isSelected}
       theme={theme}
-      role={isButton && 'button'}
-      style={isButton ? { cursor: 'pointer' } : null}
+      role={isButton && "button"}
+      style={isButton ? { cursor: "pointer" } : null}
       tabIndex={isButton ? 0 : -1}
       onClick={clicked}
-      onKeyUp={(e) => e.code === 'Space' && clicked()}
+      onKeyUp={(e) => e.code === "Space" && clicked()}
     >
       {type}
     </StyledHashtag>
@@ -80,14 +80,14 @@ export default function Hashtag({ type, isSelected, isButton, clicked }) {
 
 Hashtag.propTypes = {
   type: oneOf([
-    'CSS',
-    'JavaScript',
-    'OS',
-    'Database',
-    'Network',
-    'Front-End',
-    'Back-End',
-    'All',
+    "CSS",
+    "JavaScript",
+    "OS",
+    "Database",
+    "Network",
+    "Front-End",
+    "Back-End",
+    "All",
   ]),
   isSelected: bool,
   isButton: bool,

--- a/client/src/containers/QnADialog/QnADialog.js
+++ b/client/src/containers/QnADialog/QnADialog.js
@@ -1,18 +1,18 @@
-import { useEffect, useState } from 'react';
-import Portal from 'components/Portal/Portal';
-import Dialog from 'components/Dialog/Dialog';
-import Card from 'components/Card/Card';
-import QnAContent from 'components/Content/QnAContent';
-import Divider from 'components/Divider/Divider';
-import Hashtag from 'components/Hashtag/Hashtag';
-import styled from 'styled-components';
+import { useEffect, useState } from "react";
+import Portal from "components/Portal/Portal";
+import Dialog from "components/Dialog/Dialog";
+import Card from "components/Card/Card";
+import QnAContent from "components/Content/QnAContent";
+import Divider from "components/Divider/Divider";
+import Hashtag from "components/Hashtag/Hashtag";
+import styled from "styled-components";
 import {
   boxShadowBlack,
   spoqaMedium,
   spoqaMediumLight,
-} from 'styles/common/common.styled';
-import { bool, object } from 'prop-types';
-import API from 'api/api';
+} from "styles/common/common.styled";
+import { bool, object } from "prop-types";
+import API from "api/api";
 
 /* ---------------------------- styled components --------------------------- */
 const CardContainer = styled.div`
@@ -67,32 +67,17 @@ const AnswerContainer = styled.div`
 /* ------------------------------- 답변 영역 분기 처리 ------------------------------ */
 const Answers = ({ answersList = [] }) => {
   if (!answersList.length) {
-    return (
-      <QnAContent
-        answer={false}
-        isEllipsis={false}
-      />
-    )
+    return <QnAContent answer={false} isEllipsis={false} />;
   }
 
   return (
     answersList !== [] &&
     answersList.map((answer) => {
       return (
-        <>
-          <QnAContent
-            key={answer._id + 1}
-            answer={answer}
-            isEllipsis={false}
-          />
-          <Divider
-            key={answer._id + 2}
-            primary={false}
-            color="gray"
-            height="1px"
-            width="50%"
-          />
-        </>
+        <div key={answer._id}>
+          <QnAContent answer={answer} isEllipsis={false} />
+          <Divider primary={false} color="gray" height="1px" width="50%" />
+        </div>
       );
     })
   );
@@ -118,8 +103,8 @@ export default function QnADialog({
   const [isAnswered, setIsAnswered] = useState(false);
 
   useEffect(() => {
-    const getIsAnswered = async questionId => {
-      const userData = await API('/api/user-profile', 'get');
+    const getIsAnswered = async (questionId) => {
+      const userData = await API("/api/user-profile", "get");
 
       userData[0].answeredQuestions.forEach(({ _id }) => {
         if (_id === questionId) setIsAnswered(true);
@@ -138,22 +123,22 @@ export default function QnADialog({
   if (!Object.keys(question).length) return null;
 
   return (
-    <Portal id={'dialog-container'}>
+    <Portal id={"dialog-container"}>
       <Dialog
         visible={isVisible} // 상위 컴포넌트의 state로 handle
         label="QnA 상세 내용"
         onClick={onClick}
       >
         <CardContainer>
-        <Card isDialog isQuestion title={question.content}>
-          <HashtagContainer>
-            {question.hashTag.map((keyword, idx) => {
-              return <Hashtag key={idx} type={keyword} />
-            })}
-          </HashtagContainer>
-          <Answers answersList={question.answers} />
-          <InputArea isAnswered={isAnswered} />
-        </Card>
+          <Card isDialog isQuestion title={question.content}>
+            <HashtagContainer>
+              {question.hashTag.map((keyword, idx) => {
+                return <Hashtag key={idx} type={keyword} />;
+              })}
+            </HashtagContainer>
+            <Answers answersList={question.answers} />
+            <InputArea isAnswered={isAnswered} />
+          </Card>
         </CardContainer>
       </Dialog>
     </Portal>

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -100,7 +100,11 @@ export default function HomePage() {
       >
         {/* 랜덤 QnA 카드 섹션 */}
         {randomQData && !isRandomQLoading ? (
-          <Card isQuestion={true} title={randomQData.content}>
+          <Card
+            isQuestion={true}
+            title={randomQData.content}
+            tags={randomQData.hashTag}
+          >
             <QnAContent
               answer={
                 randomQData.answers &&
@@ -123,7 +127,7 @@ export default function HomePage() {
             />
           </Card>
         ) : (
-          <SkeletonCard variant="rect" animation="wave" height="13em" />
+          <SkeletonCard variant="rect" animation="wave" height="16em" />
         )}
 
         {/* 명언 카드 섹션 */}

--- a/client/src/pages/ProfilePage/ProfilePage.js
+++ b/client/src/pages/ProfilePage/ProfilePage.js
@@ -42,9 +42,13 @@ export default function ProfilePage() {
       return "작성한 답변이 없어요";
     } else if (userProfile && userProfile[0].answeredQuestions) {
       return userProfile[0].answeredQuestions.map((data) => (
-        <Card key={data._id} isQuestion={true} title={data.content}>
+        <Card
+          key={data._id}
+          isQuestion={true}
+          title={data.content}
+          tags={hashTag}
+        >
           <QnAContent
-            key={data._id}
             answer={data.answers.find(
               (answer) => answer.postedby?._id === authUser._id
             )}

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -75,6 +75,7 @@ function ResultsSection({ result = [], word = "" }) {
             key={data._id + "a"}
             isQuestion={true}
             title={data.content}
+            tags={data.hashTag}
             onClick={() => handleDialog(data._id)}
           >
             <QnAContent


### PR DESCRIPTION
## 개요

- wokring on 81
- Card 컴포넌트에 배열을 받는 tags prop 추가. 



## 작업사항
- 카드 컴포넌트에 hashTag정보를 받아 보여줄수있도록 tags prop를 추가함 (범용적으로 쓰일수 있도록 tag라고 작명)
- 태그가 1개 ~ 3개일때 전부 정상적으로 작동하도록 styled component 설계
- 프로필, 검색, 메인 페이지 QnA 카드에 적용
- 누락된 proptypes 체크 추가 및 스토리북 작성

![Screen Shot 2021-04-22 at 3 26 24 pm](https://user-images.githubusercontent.com/40879385/115666112-1f864780-a37f-11eb-858e-37b6c2ad3b9d.jpg)

