### PR TITLE
fix: 라우트 가드 문제 해결

### DIFF
--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -107,7 +107,7 @@ export default function Profile({ user }) {
         )}
       </div>
       <div className="hashtags">
-        {hashtag.length !== 0 ? (
+        {hashtag && hashtag.length !== 0 ? (
           hashtag.map((tag) => <Hashtag key={tag} type={tag} />)
         ) : (
           <StyledLink

--- a/client/src/components/RouteGuard/RouteGuard.js
+++ b/client/src/components/RouteGuard/RouteGuard.js
@@ -1,11 +1,21 @@
-import { Redirect, Route } from "react-router-dom";
+import { Redirect, Route, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 export default function RouteGuard(props) {
   const { isAuthed } = useSelector((state) => state.auth);
+  const currentLocation = useLocation().pathname;
+  const state = useLocation().state;
+
   if (isAuthed) {
     return <Route {...props} />;
   } else {
-    return <Redirect to="/login" />;
+    return (
+      <Redirect
+        to={{
+          pathname: "/login",
+          state: { referrer: currentLocation },
+        }}
+      />
+    );
   }
 }

--- a/client/src/pages/LoginPage/LoginPage.js
+++ b/client/src/pages/LoginPage/LoginPage.js
@@ -38,9 +38,10 @@ export default function LoginPage() {
   // 사용자가 이미 로그인 상태일때 url을 이용해 /login에 직정접으로 접근하려고 할시 홈 라우트로 이동하도록 설정
   // 인증 요청을 하고 정상적으로 인증이 됐을 경우 홈으로 이동,
   // 오류가 발생했을시는 버튼을 다시 활성화 시켜서 다시 시도할수 있도록 설정
+
   useEffect(() => {
     if (isAuthed) {
-      history.push(state?.referrer);
+      !state?.referrer ? history.push("/") : history.push(state?.referrer);
     } else if (error) {
       setDisabled(false);
     }

--- a/client/src/pages/LoginPage/LoginPage.js
+++ b/client/src/pages/LoginPage/LoginPage.js
@@ -3,7 +3,7 @@ import PageContainer from "containers/PageContainer/PageContainer.styled";
 import styled from "styled-components";
 import { pageEffect } from "styles/motions/variants";
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router";
+import { useHistory, useLocation } from "react-router";
 import Button from "components/Button/Button";
 import Icon from "components/Icon/Icon";
 import { museoLarge } from "styles/common/common.styled";
@@ -16,7 +16,6 @@ const LoginContent = styled.div`
   justify-content: center;
   height: 100%;
   margin-top: 10em;
-
   h1 {
     text-transform: uppercase;
     ${museoLarge}
@@ -24,7 +23,6 @@ const LoginContent = styled.div`
     color: var(--color-white);
     user-select: none;
   }
-
   button {
     margin-top: 5em;
   }
@@ -35,13 +33,14 @@ export default function LoginPage() {
   // 여러번 auth를 통한 인증 요청을 보내지 않도록 로그인 버튼 클릭시 disabled 설정을 해줄 상태 설정
   const [disabled, setDisabled] = useState(false);
   const history = useHistory();
+  const state = useLocation().state;
 
   // 사용자가 이미 로그인 상태일때 url을 이용해 /login에 직정접으로 접근하려고 할시 홈 라우트로 이동하도록 설정
   // 인증 요청을 하고 정상적으로 인증이 됐을 경우 홈으로 이동,
   // 오류가 발생했을시는 버튼을 다시 활성화 시켜서 다시 시도할수 있도록 설정
   useEffect(() => {
     if (isAuthed) {
-      history.push("/");
+      history.push(state?.referrer);
     } else if (error) {
       setDisabled(false);
     }

--- a/client/src/pages/ProfilePage/ProfilePage.js
+++ b/client/src/pages/ProfilePage/ProfilePage.js
@@ -42,15 +42,8 @@ export default function ProfilePage() {
     }
   };
 
-  const {
-    username,
-    avatar,
-    likeCount,
-    bio,
-    tier,
-    githubRepo,
-    hashTag,
-  } = currentUserData[0];
+  const { username, avatar, likeCount, bio, tier, githubRepo, hashTag } =
+    currentUserData && currentUserData[0] ? currentUserData[0] : {};
 
   const user = {
     username,


### PR DESCRIPTION
## 개요

- closes #
- 강제 refresh시 항상 홈으로 튕기던 문제 해결

## 작업사항
 
- [리액트 라우트 공식문서 참고](https://reactrouter.com/web/api/Redirect/to-object)
- 로그인 페이지로 Redirect될시 원래 머물던곳을 기억하고 그 경로로 push해줌
- 라우트 버그 수정후 프로필 페이지내에서 리프레쉬했을시 유저데이터가 아직 불러와지지 않아 생기는 버그 수정
 
