### PR TITLE
feat: 계정 관리 탭 리덕스 연동, 최초 로그인시 키워드 선택 표시

### DIFF
--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -3,7 +3,10 @@ import { array, func } from 'prop-types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { resetList, spoqaLarge } from 'styles/common/common.styled';
-import Portal from "components/Portal/Portal";
+import Portal from 'components/Portal/Portal';
+import { useDispatch } from 'react-redux';
+import API from 'api/api';
+import { fetchCurrentUserData } from 'redux/storage/currentUser/currentUser';
 
 const Container = styled.div`
   button {
@@ -75,7 +78,7 @@ const DoneButton = styled.button`
 
 /* ---------------------------- styled component ---------------------------- */
 
-export default function KeywordSelect({ userKeywords, onDone, onCancel }) {
+export default function KeywordSelect({ userKeywords, onClose }) {
   const [selectedKeywords, setSelectedKeywords] = useState(
     userKeywords.length ? userKeywords : []
   );
@@ -91,52 +94,54 @@ export default function KeywordSelect({ userKeywords, onDone, onCancel }) {
 
   const dialogRef = React.useRef(null);
 
+  const dispatch = useDispatch();
+
   // a11y
   React.useEffect(() => {
-      const dialogNode = dialogRef.current;
-      dialogNode.setAttribute("tabIndex", -1);
-      dialogNode.focus();
+    const dialogNode = dialogRef.current;
+    dialogNode.setAttribute('tabIndex', -1);
+    dialogNode.focus();
 
-      // 다이얼로그 뒤에 영역이 모바일 보이스리더기에 읽히지 않도록 처리
-      const rootNode = document.getElementById("root");
-      rootNode.setAttribute("aria-hidden", true);
-      rootNode.style.userSelect = "none";
+    // 다이얼로그 뒤에 영역이 모바일 보이스리더기에 읽히지 않도록 처리
+    const rootNode = document.getElementById('root');
+    rootNode.setAttribute('aria-hidden', true);
+    rootNode.style.userSelect = 'none';
 
-      const handleFocusTrap = (e) => {
-        // 다이얼로그 노드
-        // const dialogNode = dialogRef.current;
-        // focusable nodes "inside" dialogNode
-        const focusableNodeList = dialogNode.querySelectorAll(
-          "a, button, input, select, textarea"
-        ); // 참고로 a 태그는 href 속성이나 tabindex 속성이 있으면 focusable함.
+    const handleFocusTrap = (e) => {
+      // 다이얼로그 노드
+      // const dialogNode = dialogRef.current;
+      // focusable nodes "inside" dialogNode
+      const focusableNodeList = dialogNode.querySelectorAll(
+        'a, button, input, select, textarea'
+      ); // 참고로 a 태그는 href 속성이나 tabindex 속성이 있으면 focusable함.
 
-        // 첫 번째 포커스 요소와 마지막 포커스 요소를 기억해놓아야
-        // 다이얼로그가 닫히지 않는 한 다이얼로그 내에서 포커싱이 순환될 수 있음.
-        const firstFocusNode = focusableNodeList[0];
-        const lastFocusNode = focusableNodeList[focusableNodeList.length - 1];
+      // 첫 번째 포커스 요소와 마지막 포커스 요소를 기억해놓아야
+      // 다이얼로그가 닫히지 않는 한 다이얼로그 내에서 포커싱이 순환될 수 있음.
+      const firstFocusNode = focusableNodeList[0];
+      const lastFocusNode = focusableNodeList[focusableNodeList.length - 1];
 
-        // 첫 번째 포커스 요소에서 shift + tab 동시에 누르면? -> 마지막 포커스 요소로 이동!
-        if (e.target === firstFocusNode && e.shiftKey && e.key === "Tab") {
-          e.preventDefault();
-          lastFocusNode.focus();
-        }
+      // 첫 번째 포커스 요소에서 shift + tab 동시에 누르면? -> 마지막 포커스 요소로 이동!
+      if (e.target === firstFocusNode && e.shiftKey && e.key === 'Tab') {
+        e.preventDefault();
+        lastFocusNode.focus();
+      }
 
-        // 마지막 포커스 요소에서 tab 누르면? -> 첫 번째 포커스 요소로 이동!
-        if (e.target === lastFocusNode && !e.shiftKey && e.key === "Tab") {
-          e.preventDefault();
-          firstFocusNode.focus();
-        }
-      };
+      // 마지막 포커스 요소에서 tab 누르면? -> 첫 번째 포커스 요소로 이동!
+      if (e.target === lastFocusNode && !e.shiftKey && e.key === 'Tab') {
+        e.preventDefault();
+        firstFocusNode.focus();
+      }
+    };
 
-      window.addEventListener("keydown", handleFocusTrap);
+    window.addEventListener('keydown', handleFocusTrap);
 
-      // clean-up function
-      return () => {
-        dialogNode.removeAttribute("tabIndex");
-        rootNode.removeAttribute("aria-hidden");
-        window.removeEventListener("keydown", handleFocusTrap);
-        rootNode.style.userSelect = "auto";
-      };
+    // clean-up function
+    return () => {
+      dialogNode.removeAttribute('tabIndex');
+      rootNode.removeAttribute('aria-hidden');
+      window.removeEventListener('keydown', handleFocusTrap);
+      rootNode.style.userSelect = 'auto';
+    };
   }, []);
 
   const handleClick = (keyword) => {
@@ -152,21 +157,23 @@ export default function KeywordSelect({ userKeywords, onDone, onCancel }) {
     }
   };
 
-  const submitSelectedKeywords = () => {
-    if (userKeywords === selectedKeywords) {
-      onCancel();
-      return;
+  const submitSelectedKeywords = async () => {
+    if (userKeywords !== selectedKeywords) {
+      await API('/api/user-profile/hashtag', 'patch', {
+        hashTag: selectedKeywords,
+      });
+      dispatch(fetchCurrentUserData());
     }
-    onDone(selectedKeywords);
+    onClose();
   };
 
   const cancelKeywordSelect = () => {
     setSelectedKeywords(userKeywords.length ? userKeywords : []);
-    onCancel();
+    onClose();
   };
 
   return (
-    <Portal id={"dialog-container"}>
+    <Portal id={'dialog-container'}>
       <Container ref={dialogRef} label="관심 키워드 선택 다이얼로그">
         <CancelButton onClick={cancelKeywordSelect}>Cancel</CancelButton>
         <Backdrop $opacity={0.8} />

--- a/client/src/components/KeywordSelect/KeywordSelect.js
+++ b/client/src/components/KeywordSelect/KeywordSelect.js
@@ -13,7 +13,7 @@ const Container = styled.div`
     background-color: transparent;
     border: none;
     ${spoqaLarge}
-    position: absolute;
+    position: fixed;
     top: 1.5em;
     z-index: 999;
     cursor: pointer;
@@ -161,6 +161,9 @@ export default function KeywordSelect({ userKeywords, onClose }) {
     if (userKeywords !== selectedKeywords) {
       await API('/api/user-profile/hashtag', 'patch', {
         hashTag: selectedKeywords,
+      });
+      await API('/api/user-profile/first-login', 'patch', {
+        firstLogin: false,
       });
       dispatch(fetchCurrentUserData());
     }

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -1,11 +1,10 @@
-import axios from "axios";
-import Hashtag from "components/Hashtag/Hashtag";
-import Icon from "components/Icon/Icon";
-import Tier from "components/Tier/Tier";
-import React, { useState, useEffect } from "react";
-import { signOutAction } from "redux/storage/auth/auth";
-import { useDispatch } from "react-redux";
-import styled from "styled-components";
+import Hashtag from 'components/Hashtag/Hashtag';
+import Icon from 'components/Icon/Icon';
+import Tier from 'components/Tier/Tier';
+import React, { useState, useEffect } from 'react';
+import { signOutAction } from 'redux/storage/auth/auth';
+import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
 import {
   museoLarge,
   spoqaMedium,
@@ -13,11 +12,14 @@ import {
   spoqaSmallBold,
   boxShadowBlack,
   resetBoxModel,
-} from "styles/common/common.styled";
-import API from "api/api";
-import { confirmAlert } from "react-confirm-alert";
-import "react-confirm-alert/src/react-confirm-alert.css";
-import KeywordSelect from "components/KeywordSelect/KeywordSelect";
+} from 'styles/common/common.styled';
+import API from 'api/api';
+import { confirmAlert } from 'react-confirm-alert';
+import 'react-confirm-alert/src/react-confirm-alert.css';
+import KeywordSelect from 'components/KeywordSelect/KeywordSelect';
+import { useSelector } from 'react-redux';
+import { fetchCurrentUserData } from 'redux/storage/currentUser/currentUser';
+import { ReactComponent as Spinner } from '../Spinner/Spinner.svg';
 
 /* -------------------------------------------------------------------------- */
 
@@ -286,27 +288,31 @@ const Loading = styled.p`
 /* ---------------------------- styled components --------------------------- */
 
 export default function MyInfo() {
-  const [user, setUser] = useState(null);
   const [isBioActive, setIsBioActive] = useState(false);
-  const [enteredBio, setEnteredBio] = useState("");
+  const [enteredBio, setEnteredBio] = useState('');
   const [isSelectingKeywords, setIsSelectingKeywords] = useState(false);
 
   const dispatch = useDispatch();
 
-  const getUser = async () => {
-    const res = await axios.get("/api/user-profile");
-    const userData = res.data[0];
-    setUser(userData);
-    setEnteredBio(userData.bio);
-  };
+  let user = null;
+
+  const { currentUserData, isLoading } = useSelector(
+    (state) => state.currentUser
+  );
 
   useEffect(() => {
-    getUser();
-    return () => {
-      setUser(null);
-      setEnteredBio("");
-    };
-  }, []);
+    if (user) setEnteredBio(user.bio);
+  }, [user, currentUserData]);
+
+  if (isLoading) {
+    return (
+      <Loading>
+        <Spinner />
+      </Loading>
+    );
+  }
+
+  user = currentUserData[0];
 
   const handleBioChange = (e) => {
     setEnteredBio(e.target.value);
@@ -316,11 +322,11 @@ export default function MyInfo() {
     setIsSelectingKeywords(true);
   };
 
-  const handleDoneHashtagChange = (selectedKeywords) => {
-    API("/api/user-profile/hashtag", "patch", { hashTag: selectedKeywords });
-    setUser((prev) => {
-      return { ...prev, hashTag: selectedKeywords };
+  const handleDoneHashtagChange = async (selectedKeywords) => {
+    await API('/api/user-profile/hashtag', 'patch', {
+      hashTag: selectedKeywords,
     });
+    dispatch(fetchCurrentUserData());
     setIsSelectingKeywords(false);
   };
 
@@ -328,14 +334,10 @@ export default function MyInfo() {
     setIsSelectingKeywords(false);
   };
 
-  const handleClickBioButton = () => {
-    if (isBioActive) {
-      if (enteredBio === user.bio) {
-        setIsBioActive(!isBioActive);
-        return;
-      }
-
-      API("/api/user-profile/bio", "patch", { bio: enteredBio });
+  const handleClickBioButton = async () => {
+    if (isBioActive && user.bio !== enteredBio) {
+      await API('/api/user-profile/bio', 'patch', { bio: enteredBio });
+      dispatch(fetchCurrentUserData());
     }
     setIsBioActive(!isBioActive);
   };
@@ -345,6 +347,10 @@ export default function MyInfo() {
   };
 
   const handleDelete = () => {
+    const deleteAccount = async () => {
+      await API('/api/user', 'delete');
+      dispatch(signOutAction());
+    };
     confirmAlert({
       customUI: ({ onClose }) => {
         return (
@@ -354,9 +360,8 @@ export default function MyInfo() {
             <div>
               <button onClick={onClose}>취소</button>
               <button
-                onClick={async () => {
-                  await API("/api/user", "delete");
-                  dispatch(signOutAction());
+                onClick={() => {
+                  deleteAccount();
                   onClose();
                 }}
               >
@@ -369,68 +374,64 @@ export default function MyInfo() {
     });
   };
 
-  if (user) {
-    return (
-      <>
-        {isSelectingKeywords && (
-          <KeywordSelect
-            userKeywords={user.hashTag}
-            onDone={handleDoneHashtagChange}
-            onCancel={handleCancelHashtagChange}
+  return (
+    <>
+      {isSelectingKeywords && (
+        <KeywordSelect
+          userKeywords={user.hashTag}
+          onDone={handleDoneHashtagChange}
+          onCancel={handleCancelHashtagChange}
+        />
+      )}
+      <StyledMyInfo>
+        <StyledProfile>
+          <img src={user.avatar} alt={user.username} />
+          <div className="info">
+            <p>{user.username}</p>
+            <div className="tierContainer">
+              <Tier tier={user.tier} />
+              <Icon type="heart-active" title="likes" />
+              <span>{user.likeCount}</span>
+            </div>
+            <a href={user.githubRepo}>{user.githubRepo}</a>
+          </div>
+        </StyledProfile>
+        <div className="bio__container">
+          <div className="bio__heading-container">
+            <h3>자기소개</h3>
+            <button onClick={handleClickBioButton}>
+              {isBioActive ? '완료' : '수정'}
+            </button>
+          </div>
+          <textarea
+            disabled={!isBioActive}
+            id="bio"
+            value={enteredBio}
+            onChange={(e) => handleBioChange(e)}
+            maxLength="119"
           />
-        )}
-        <StyledMyInfo>
-          <StyledProfile>
-            <img src={user.avatar} alt={user.username} />
-            <div className="info">
-              <p>{user.username}</p>
-              <div className="tierContainer">
-                <Tier tier={user.tier} />
-                <Icon type="heart-active" title="likes" />
-                <span>{user.likeCount}</span>
-              </div>
-              <a href={user.githubRepo}>{user.githubRepo}</a>
-            </div>
-          </StyledProfile>
-          <div className="bio__container">
-            <div className="bio__heading-container">
-              <h3>자기소개</h3>
-              <button onClick={handleClickBioButton}>
-                {isBioActive ? "완료" : "수정"}
-              </button>
-            </div>
-            <textarea
-              disabled={!isBioActive}
-              id="bio"
-              value={enteredBio}
-              onChange={(e) => handleBioChange(e)}
-              maxLength="119"
-            />
-            {isBioActive && <span>{enteredBio.length}/120</span>}
+          {isBioActive && <span>{enteredBio.length}/120</span>}
+        </div>
+        <div className="hashtag__container">
+          <div className="hashtag__heading-container">
+            <h3>관심 키워드</h3>
+            <button onClick={handleStartHashtagChange}>수정</button>
           </div>
-          <div className="hashtag__container">
-            <div className="hashtag__heading-container">
-              <h3>관심 키워드</h3>
-              <button onClick={handleStartHashtagChange}>수정</button>
-            </div>
-            <div className="hashtag__hashtags">
-              {user.hashTag.map((ht) => {
-                return <Hashtag key={ht} type={ht} />;
-              })}
-            </div>
+          <div className="hashtag__hashtags">
+            {user.hashTag.map((ht) => {
+              return <Hashtag key={ht} type={ht} />;
+            })}
           </div>
-          <div className="button__container">
-            <button className="signout" onClick={handleSignOut}>
-              로그아웃
-            </button>
-            <button className="delete-account" onClick={handleDelete}>
-              회원탈퇴
-            </button>
-          </div>
-        </StyledMyInfo>
-      </>
-    );
-  }
-
-  return <Loading>Loading...</Loading>;
+        </div>
+        <div className="button__container">
+          <button className="signout" onClick={handleSignOut}>
+            로그아웃
+          </button>
+          <button className="delete-account" onClick={handleDelete}>
+            회원탈퇴
+          </button>
+        </div>
+      </StyledMyInfo>
+    </>
+  );
 }

--- a/client/src/components/MyInfo/MyInfo.js
+++ b/client/src/components/MyInfo/MyInfo.js
@@ -318,19 +318,11 @@ export default function MyInfo() {
     setEnteredBio(e.target.value);
   };
 
-  const handleStartHashtagChange = () => {
+  const handleOpenHashtagChange = () => {
     setIsSelectingKeywords(true);
   };
 
-  const handleDoneHashtagChange = async (selectedKeywords) => {
-    await API('/api/user-profile/hashtag', 'patch', {
-      hashTag: selectedKeywords,
-    });
-    dispatch(fetchCurrentUserData());
-    setIsSelectingKeywords(false);
-  };
-
-  const handleCancelHashtagChange = () => {
+  const handleCloseHashtagChange = () => {
     setIsSelectingKeywords(false);
   };
 
@@ -379,8 +371,7 @@ export default function MyInfo() {
       {isSelectingKeywords && (
         <KeywordSelect
           userKeywords={user.hashTag}
-          onDone={handleDoneHashtagChange}
-          onCancel={handleCancelHashtagChange}
+          onClose={handleCloseHashtagChange}
         />
       )}
       <StyledMyInfo>
@@ -415,7 +406,7 @@ export default function MyInfo() {
         <div className="hashtag__container">
           <div className="hashtag__heading-container">
             <h3>관심 키워드</h3>
-            <button onClick={handleStartHashtagChange}>수정</button>
+            <button onClick={handleOpenHashtagChange}>수정</button>
           </div>
           <div className="hashtag__hashtags">
             {user.hashTag.map((ht) => {

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -1,22 +1,23 @@
-import React, { useEffect, useState } from "react";
-import PageContainer from "containers/PageContainer/PageContainer.styled";
-import styled from "styled-components";
-import { useSelector, useDispatch } from "react-redux";
-import { fetchHardWorkersData } from "redux/storage/hardWorkers/hardWorkers";
-import { fetchTrendingData } from "redux/storage/trendingQ/trendingQ";
-import { fetchRandomQuoteData } from "redux/storage/quote/quote";
-import { fetchRandomQData } from "redux/storage/randomQ/randomQ";
-import { pageEffect } from "styles/motions/variants";
-import TextHeaderBar from "containers/TextHeaderBar/TextHeaderBar";
-import Card from "components/Card/Card";
-import QuotesContent from "components/Content/QuotesContent";
-import ToggleButtonGroup from "@material-ui/lab/ToggleButtonGroup";
-import ToggleButton from "@material-ui/lab/ToggleButton";
-import HardWorkersContent from "components/Content/HardWorkersContent";
-import TrendingQuestionContent from "components/Content/TrendingQuestionContent";
-import QnAContent from "components/Content/QnAContent";
-import Button from "components/Button/Button";
-import { Skeleton } from "@material-ui/lab";
+import React, { useEffect, useState } from 'react';
+import PageContainer from 'containers/PageContainer/PageContainer.styled';
+import styled from 'styled-components';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchHardWorkersData } from 'redux/storage/hardWorkers/hardWorkers';
+import { fetchTrendingData } from 'redux/storage/trendingQ/trendingQ';
+import { fetchRandomQuoteData } from 'redux/storage/quote/quote';
+import { fetchRandomQData } from 'redux/storage/randomQ/randomQ';
+import { pageEffect } from 'styles/motions/variants';
+import TextHeaderBar from 'containers/TextHeaderBar/TextHeaderBar';
+import Card from 'components/Card/Card';
+import QuotesContent from 'components/Content/QuotesContent';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import HardWorkersContent from 'components/Content/HardWorkersContent';
+import TrendingQuestionContent from 'components/Content/TrendingQuestionContent';
+import QnAContent from 'components/Content/QnAContent';
+import Button from 'components/Button/Button';
+import { Skeleton } from '@material-ui/lab';
+import KeywordSelect from 'components/KeywordSelect/KeywordSelect';
 
 /* ---------------------------- styled components --------------------------- */
 
@@ -55,8 +56,12 @@ const SkeletonCard = styled(Skeleton)`
 /* -------------------------------------------------------------------------- */
 
 export default function HomePage() {
-  const [quoteLanguage, setQuoteLanguage] = useState("ko");
+  const [quoteLanguage, setQuoteLanguage] = useState('ko');
+  const [isSelectingKeywords, setIsSelectingKeywords] = useState(false);
+
   const dispatch = useDispatch();
+
+  const { currentUserData } = useSelector((state) => state.currentUser);
 
   const {
     randomQData,
@@ -83,14 +88,25 @@ export default function HomePage() {
   } = useSelector((state) => state.trendingQ);
 
   useEffect(() => {
-    dispatch(fetchRandomQData("init"));
-    dispatch(fetchRandomQuoteData("init"));
-    dispatch(fetchTrendingData("init"));
-    dispatch(fetchHardWorkersData("init"));
+    dispatch(fetchRandomQData('init'));
+    dispatch(fetchRandomQuoteData('init'));
+    dispatch(fetchTrendingData('init'));
+    dispatch(fetchHardWorkersData('init'));
   }, [dispatch]);
+
+  useEffect(() => {
+    if (currentUserData && currentUserData[0].firstLogin)
+      setIsSelectingKeywords(true);
+  }, [currentUserData]);
 
   return (
     <>
+      {isSelectingKeywords && (
+        <KeywordSelect
+          userKeywords={currentUserData[0].hashTag}
+          onClose={() => setIsSelectingKeywords(false)}
+        />
+      )}
       <TextHeaderBar page="home" />
       <PageContainer
         page="home"
@@ -148,14 +164,14 @@ export default function HomePage() {
             <ToggleButton
               value="ko"
               aria-label="번역된 명언 보기"
-              disabled={quoteLanguage === "ko"}
+              disabled={quoteLanguage === 'ko'}
             >
               ko
             </ToggleButton>
             <ToggleButton
               value="en"
               aria-label="원문 명언 보기"
-              disabled={quoteLanguage === "en"}
+              disabled={quoteLanguage === 'en'}
             >
               en
             </ToggleButton>

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -18,6 +18,7 @@ import QnAContent from 'components/Content/QnAContent';
 import Button from 'components/Button/Button';
 import { Skeleton } from '@material-ui/lab';
 import KeywordSelect from 'components/KeywordSelect/KeywordSelect';
+import API from 'api/api';
 
 /* ---------------------------- styled components --------------------------- */
 


### PR DESCRIPTION
## 개요

- 계정 관리 탭 리덕스 연동, 최초 로그인시 키워드 선택 표시


## 작업사항

- My Info 탭과 Redux- Current User State를 연동
- 홈페이지에서 Current User의 firstLogin이 true이면 관심 키워드 다이얼로그 표시
<img width="370" alt="Screen Shot 2021-04-23 at 1 30 56 PM" src="https://user-images.githubusercontent.com/72863748/115818898-bc58eb80-a438-11eb-944c-721f0c13192b.png">
