### PR TITLE
feat: Suits 탭에 image lazy load 추가

### DIFF
--- a/client/src/components/Suits/Suits.js
+++ b/client/src/components/Suits/Suits.js
@@ -23,6 +23,7 @@ const StylesSuits = styled.section`
     display: block;
     box-sizing: border-box;
     margin-bottom: 2em;
+    border-radius: 50%;
   }
   .heading {
     text-align: center;
@@ -128,9 +129,39 @@ const StylesSuits = styled.section`
 `;
 
 export default function Suits() {
+  const handleLoaded = (e) => {
+    let imgSrc = '';
+    switch (e.target.alt) {
+      case '안예인':
+        imgSrc = ahn;
+        break;
+      case '서민기':
+        imgSrc = suh;
+        break;
+      case '박재운':
+        imgSrc = park;
+        break;
+      case 'Suits 로고':
+        imgSrc = logo;
+        break;
+
+      default:
+        break;
+    }
+    e.target.src = imgSrc;
+  };
+
+  const placeHolder =
+    'https://via.placeholder.com/150x150.png?text=Place+Holder';
+
   return (
     <StylesSuits>
-      <img src={logo} alt="Suits 로고" className="logo" />
+      <img
+        src={placeHolder}
+        alt="Suits 로고"
+        className="logo"
+        onLoad={handleLoaded}
+      />
       <h3 className="heading">
         기술 면접을 준비하는 단정한 습관<em>Suits</em>
       </h3>
@@ -148,21 +179,21 @@ export default function Suits() {
         <div className="members">
           <a href="https://github.com/ahnanne">
             <figure>
-              <img src={ahn} alt="안예인" />
+              <img src={placeHolder} alt="안예인" onLoad={handleLoaded} />
 
               <figcaption>Ahn Yein</figcaption>
             </figure>
           </a>
           <a href="https://github.com/minki607">
             <figure>
-              <img src={suh} alt="서민기" />
+              <img src={placeHolder} alt="서민기" onLoad={handleLoaded} />
 
               <figcaption>Suh Mingee</figcaption>
             </figure>
           </a>
           <a href="https://github.com/fe-kid">
             <figure>
-              <img src={park} alt="박재운" />
+              <img src={placeHolder} alt="박재운" onLoad={handleLoaded} />
 
               <figcaption>Park Jaewoon</figcaption>
             </figure>


### PR DESCRIPTION
## 개요

- closes #88

- Suits 탭에 image lazy load 추가


## 작업사항

- 최초에 img 요소의 src 어트리뷰트에 Placeholder 이미지를 부여하고, on load 감지시 원하는 이미지 url로 src를 교체함
- Placeholder는 임시로 https://placeholder.com/ 에서 제공하는 이미지를 사용했음
- 결과적으로 load 전후 레이아웃 차이를 없앨 수 있었음
- Placeholder 이미지는 마스코트 슈티 이미지를 150px짜리 작은 파일로 만들어 사용하면 좋을 것 같음
<img width="573" alt="Screen Shot 2021-04-25 at 12 00 25 PM" src="https://user-images.githubusercontent.com/72863748/115979046-94939000-a5be-11eb-8c9b-8f15af32bc6e.png">
