### PR TITLE
feat: Suits 탭 margin-top 수정, Answer placeholder 추가

### DIFF
--- a/client/src/components/Suits/Suits.js
+++ b/client/src/components/Suits/Suits.js
@@ -15,7 +15,7 @@ const StylesSuits = styled.section`
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  margin-top: 20vh;
+  margin-top: 70px;
   .logo {
     width: 100px;
     display: block;

--- a/client/src/containers/AnswerContainer/AnswerContainer.js
+++ b/client/src/containers/AnswerContainer/AnswerContainer.js
@@ -143,7 +143,12 @@ export default function Answers({ answersList = [], userId = '', removeAnswer, p
             <React.Fragment key={answer._id}>
               {editing === answer._id ? (
                 <EditContainer>
-                  <EditArea value={editContent} onChange={(e) => handleEditContent(e)} maxLength="200" />
+                  <EditArea
+                    value={editContent}
+                    onChange={(e) => handleEditContent(e)}
+                    maxLength="200"
+                    placeholder="답변을 10자 이상 입력해주세요."
+                  />
                   {editing && <EditContentLength>{editContent ? editContent.length : 0}/200</EditContentLength>}
                   <EditConfirmButton
                     disabled={isDisabled}

--- a/client/src/containers/AnswerInput/AnswerInput.js
+++ b/client/src/containers/AnswerInput/AnswerInput.js
@@ -99,7 +99,11 @@ export default function InputArea({ isAnswered, isInputLoading, questionId, hand
   return (
     <AnswerContainer>
       <StyledTextAreaContainer>
-        <StyledTextarea onChange={(e) => handleContent(e)} maxLength="200" />
+        <StyledTextarea
+          onChange={(e) => handleContent(e)}
+          maxLength="200"
+          placeholder="답변을 10자 이상 입력해주세요."
+        />
         <StyledContentLength>{content ? content.length : 0}/200</StyledContentLength>
       </StyledTextAreaContainer>
       <StyledButton disabled={isDisabled} onClick={() => postAnswer(content, handleDisabled, handleEmptyContent)}>


### PR DESCRIPTION
## 개요

- Suits 탭 margin-top 수정, Answer placeholder 추가


## 작업사항

- Suits 탭 margin-top 수정
- Answer textarea에 placeholder 추가
<img width="333" alt="Screen Shot 2021-04-29 at 4 07 47 PM" src="https://user-images.githubusercontent.com/72863748/116513801-14926080-a905-11eb-8751-20143aa8b582.png">
