### PR TITLE
feat: PostPage Header 스크롤 이펙트 추가

### DIFF
--- a/client/src/components/Content/AdBanner.js
+++ b/client/src/components/Content/AdBanner.js
@@ -43,6 +43,7 @@ const StyledSlider = styled(Slider)`
     }
   }
   .slick-dots {
+    bottom: -35px;
     button:before {
       color: var(--color-text);
     }
@@ -55,12 +56,12 @@ const adList = [
   {
     name: '데브폴리오',
     src: '/assets/ad-devfolio.png',
-    url: 'https://github.com/Devfolio-team/Devfolio-Client',
+    url: 'http://devfolio.world/',
   },
   {
     name: '산타',
     src: '/assets/ad-santa.png',
-    url: 'https://github.com/Santa-Application/App',
+    url: 'http://www.santa-application.com/',
   },
   {
     name: '우연히, 식단',
@@ -70,7 +71,7 @@ const adList = [
   {
     name: '살롱',
     src: '/assets/ad-salon.png',
-    url: 'https://github.com/riding-bom/salon',
+    url: 'https://salon-riding-bom.web.app/',
   },
 ];
 

--- a/client/src/components/Hashtag/Hashtag.js
+++ b/client/src/components/Hashtag/Hashtag.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { bool, oneOf } from 'prop-types';
 import { boxShadow, spoqaSmallBold } from 'styles/common/common.styled';
+import getHashTagColor from 'utils/getHashTagColor/getHashTagColor';
 
 /* ---------------------------- styled components --------------------------- */
 const handleButtonTheme = (type, isSelected, theme) => {
@@ -38,45 +39,12 @@ const StyledHashtag = styled.div`
 
 /* -------------------------------------------------------------------------- */
 export default function Hashtag({ type, isSelected, isButton, children, clicked }) {
-  let theme = '';
-
-  switch (type) {
-    case 'All':
-      theme = '--color-text';
-      break;
-    case 'CSS':
-      theme = '--color-blue1';
-      break;
-    case 'JavaScript':
-      theme = '--color-yellow';
-      break;
-    case 'OS':
-      theme = '--color-green1';
-      break;
-    case 'Database':
-      theme = '--color-purple';
-      break;
-    case 'Network':
-      theme = '--color-blue2';
-      break;
-    case 'Front-End':
-      theme = '--color-green2';
-      break;
-    case 'Back-End':
-      theme = '--color-orange2';
-      break;
-    case 'ETC':
-      theme = '--color-gray2';
-      break;
-    default:
-      break;
-  }
   return (
     <StyledHashtag
       $type={type}
       isButton={isButton}
       isSelected={isSelected}
-      theme={theme}
+      theme={getHashTagColor(type)}
       role={isButton && 'button'}
       aria-label={isButton ? type : ''}
       title={isButton ? type : ''}

--- a/client/src/components/Icon/Icon.js
+++ b/client/src/components/Icon/Icon.js
@@ -94,11 +94,7 @@ export default function Icon({ type, title = type, height = '25px', ...restProps
       throw new Error('아이콘을 찾을수없습니다');
   }
 
-  return <COMP
-    title={type === 'arrow' ? '맨 위로 가기' : title}
-    height={height}
-    {...restProps}
-  />;
+  return <COMP title={type === title} height={height} {...restProps} />;
 }
 
 Icon.propTypes = {

--- a/client/src/components/ScrollToTop/ScrollToTop.js
+++ b/client/src/components/ScrollToTop/ScrollToTop.js
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 import Icon from 'components/Icon/Icon';
 import { func } from 'prop-types';
+import useScrollDetect from 'hooks/useScrollDetect';
 
 /* ---------------------------- styled components --------------------------- */
+
 const PositionContainer = styled.div`
   position: fixed;
   width: 100%;
-  top: 90px;
+  top: 120px;
   z-index: 1000;
 
   // 데스크탑
@@ -18,17 +20,18 @@ const PositionContainer = styled.div`
 const TopButton = styled.button.attrs(() => ({
   type: 'button',
   title: '맨 위로 가기',
-  'aria-label': '맨 위로 가기'
+  'aria-label': '맨 위로 가기',
 }))`
   position: absolute;
   top: 0;
   right: 0;
   border: none;
   background-color: transparent;
+  opacity: ${({ isScrolled }) => (isScrolled ? 1 : 0)};
 
   // 아이콘 스타일링
   svg {
-    opacity: .7;
+    opacity: 0.7;
     filter: drop-shadow(2px 2px 10px var(--color-gray2));
 
     rect {
@@ -45,10 +48,12 @@ const TopButton = styled.button.attrs(() => ({
 
 /* ------------------------------ scroll to top ----------------------------- */
 export default function ScrollToTop({ handleClick }) {
+  const isScrolled = useScrollDetect();
+
   return (
     <PositionContainer>
-      <TopButton onClick={handleClick}>
-        <Icon type="arrow" height="40px" />
+      <TopButton onClick={handleClick} isScrolled={isScrolled}>
+        <Icon type="arrow" title="맨 위로 가기" height="40px" />
       </TopButton>
     </PositionContainer>
   );

--- a/client/src/containers/AnswerInput/AnswerInput.js
+++ b/client/src/containers/AnswerInput/AnswerInput.js
@@ -32,7 +32,7 @@ const StyledTextAreaContainer = styled.div`
 
   // 모바일
   @media screen and (max-width: 480px) {
-    width: 80%;
+    width: 100%;
   }
 `;
 
@@ -71,6 +71,11 @@ const StyledButton = styled.button.attrs((props) => ({
   cursor: ${({ disabled }) => (disabled ? 'wait' : 'pointer')};
   color: var(--color-gray1);
   font-size: 1.6rem;
+  padding: 0.5em;
+
+  @media screen and (max-width: 480px) {
+    width: 100%;
+  }
 `;
 
 /* ------------------------------- input area ------------------------------- */

--- a/client/src/containers/PageContainer/PageContainer.styled.js
+++ b/client/src/containers/PageContainer/PageContainer.styled.js
@@ -31,7 +31,7 @@ const PageContainer = styled(motion(Container))`
       > div {
         margin-bottom: 3em;
         &:first-of-type {
-          @media screen and (max-width: 375px) {
+          @media screen and (max-width: 480px) {
             margin-bottom: 1em;
           }
         }

--- a/client/src/containers/PageContainer/PageContainer.styled.js
+++ b/client/src/containers/PageContainer/PageContainer.styled.js
@@ -136,12 +136,6 @@ const PageContainer = styled(motion(Container))`
       justify-content: flex-start;
 
       // mobile
-      @media screen and (max-width: 480px) {
-        > div {
-          max-width: 350px;
-          min-width: 350px;
-        }
-      }
     `}
 `;
 export default PageContainer;

--- a/client/src/containers/PageContainer/PageContainer.styled.js
+++ b/client/src/containers/PageContainer/PageContainer.styled.js
@@ -132,7 +132,7 @@ const PageContainer = styled(motion(Container))`
   ${({ page }) =>
     page === 'post' &&
     css`
-      margin: 45px 0;
+      margin: 240px 0; // navbar + title header
       justify-content: flex-start;
 
       // mobile

--- a/client/src/hooks/useScrollDetect.js
+++ b/client/src/hooks/useScrollDetect.js
@@ -6,9 +6,7 @@ export default function useScrollDetect() {
 
   const detectScroll = () => {
     let scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
-
-    console.log(scrollTop);
-    if (scrollTop > 45) {
+    if (scrollTop >= 45) {
       setIsScrolled(true);
     } else {
       setIsScrolled(false);

--- a/client/src/hooks/useScrollDetect.js
+++ b/client/src/hooks/useScrollDetect.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import _ from 'lodash';
+
+export default function useScrollDetect() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const detectScroll = () => {
+    const scrollY = window.pageYOffset;
+    console.log(scrollY);
+    if (scrollY > 0) {
+      setIsScrolled(true);
+    } else {
+      setIsScrolled(false);
+    }
+  };
+
+  const throttledScroll = _.throttle(detectScroll, 500);
+
+  useEffect(() => {
+    window.addEventListener('scroll', throttledScroll);
+    return () => {
+      window.removeEventListener('scroll', throttledScroll);
+    };
+  }, [throttledScroll]);
+
+  return isScrolled;
+}

--- a/client/src/hooks/useScrollDetect.js
+++ b/client/src/hooks/useScrollDetect.js
@@ -5,9 +5,10 @@ export default function useScrollDetect() {
   const [isScrolled, setIsScrolled] = useState(false);
 
   const detectScroll = () => {
-    const scrollY = window.pageYOffset;
-    console.log(scrollY);
-    if (scrollY > 0) {
+    let scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+
+    console.log(scrollTop);
+    if (scrollTop > 45) {
       setIsScrolled(true);
     } else {
       setIsScrolled(false);

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -61,7 +61,7 @@ export default function HomePage() {
       dispatch(fetchRandomQData('refresh', currentQId));
       setNeedRefresh(false);
     }
-  }, [dispatch, needRefresh]);
+  }, [dispatch, currentQId, needRefresh]);
 
   useEffect(() => {
     dispatch(fetchRandomQData('init'));
@@ -70,7 +70,7 @@ export default function HomePage() {
     dispatch(fetchHardWorkersData('init'));
 
     if (randomQData) setCurrentQId(randomQData[0]._id);
-  }, [dispatch]);
+  }, [dispatch, randomQData]);
 
   // 처음 앱에 가입한 유저인 경우 키워드 설정하는 모달이 나오도록 설정
   useEffect(() => {

--- a/client/src/pages/LoginPage/LoginPage.js
+++ b/client/src/pages/LoginPage/LoginPage.js
@@ -55,7 +55,7 @@ export default function LoginPage() {
     } else if (error) {
       setDisabled(false);
     }
-  }, [history, isAuthed, error]);
+  }, [history, isAuthed, error, state]);
 
   const handleGithubLogin = () => {
     setDisabled(true);

--- a/client/src/pages/PostPage/PostPage.js
+++ b/client/src/pages/PostPage/PostPage.js
@@ -25,20 +25,20 @@ const HeadingContainer = styled.div`
   background-color: var(--color-body);
   width: 100vw;
   margin-bottom: 3em;
-  position: sticky;
-  top: 4.5em;
   display: flex;
+  position: fixed;
+  top: 4.5em;
   align-items: center;
   justify-content: center;
-  min-height: 15em;
-  transition: min-height 0.2s ease-out;
+  height: 15em;
+  transition: height 0.2s ease-out;
 
   // 스크롤된 상태일때 높이 변화
   ${({ isScrolled }) =>
     isScrolled &&
     css`
       flex-flow: column;
-      min-height: 5em;
+      height: 5em;
 
       div {
         display: flex;

--- a/client/src/pages/PostPage/PostPage.js
+++ b/client/src/pages/PostPage/PostPage.js
@@ -18,10 +18,13 @@ import { fetchCurrentUserData } from 'redux/storage/currentUser/currentUser';
 import badwordFilter from 'utils/badwordFilter/badwordFilter';
 import useScrollDetect from 'hooks/useScrollDetect';
 import getHashTagColor from 'utils/getHashTagColor/getHashTagColor';
+import ScrollToTop from 'components/ScrollToTop/ScrollToTop';
+import handleScroll from 'utils/handleScroll/handleScroll';
+import Button from 'components/Button/Button';
 
 /* ---------------------------- styled components --------------------------- */
 const HeadingContainer = styled.div`
-  z-index: 100;
+  z-index: 20;
   background-color: var(--color-body);
   width: 100vw;
   margin-bottom: 3em;
@@ -64,8 +67,7 @@ const HeadingContainer = styled.div`
 
 const StyledHeader = styled.h2`
   font-size: 2rem;
-  max-width: 50%;
-  min-width: 350px;
+  max-width: 350px;
   text-align: center;
   margin: 0 auto;
   padding-bottom: 1.4em;
@@ -94,16 +96,23 @@ const HashtagContainer = styled.div`
     `}
 `;
 
+const GoBackButton = styled(Button)`
+  position: absolute;
+  left: 2.5em;
+
+  @media screen and (max-width: 480px) {
+    left: 0;
+    bottom: -30px;
+  }
+
+  svg {
+    transform: rotate(270deg);
+  }
+`;
 // 💀 skeleton ui
 const SkeletonStyle = css`
-  /* min-width: 305px;
-  max-width: 688px; */
-  width: ${(props) => props.width};
-  margin: 1.6rem;
+  margin: 1.6rem 0;
   background-color: #e6e6e6;
-  @media screen and (max-width: 480px) {
-    margin: 1.6rem auto;
-  }
 `;
 
 const SkeletonCard = styled(Skeleton)`
@@ -119,10 +128,10 @@ const SkeletonCard = styled(Skeleton)`
 
 const SkeletonHashTag = styled(Skeleton)`
   & {
-    ${SkeletonStyle}
-    padding: 0.3em 1em;
+    margin: 0 2em;
+    padding: 1.2em 0;
     border-radius: 10px;
-    width: 7.2em;
+    width: 244px;
   }
 `;
 
@@ -138,7 +147,7 @@ const SkeletonProfile = styled.div`
 `;
 
 /* -------------------------------- post page ------------------------------- */
-export default function PostPage({ history, location, match }) {
+export default function PostPage({ history, match }) {
   // question 정보
   const { qid } = match.params;
   // const [data, setData] = useState({}); // question data
@@ -248,11 +257,19 @@ export default function PostPage({ history, location, match }) {
   }, [dispatch, questionData, qid]);
   return (
     <>
-      <TextHeaderBar page="home" />
+      <TextHeaderBar />
+      <ScrollToTop handleClick={handleScroll} />
       <PageContainer page="post" variants={pageEffect} initial="hidden" animate="visible">
         {questionData && userData ? (
           <>
             <HeadingContainer isScrolled={isScrolled} bgColor={getHashTagColor(questionData?.hashTag[0])}>
+              <GoBackButton
+                onClick={() => history.goBack()}
+                icon="arrow"
+                title="뒤로 가기"
+                aria-label="뒤로 가기"
+                isScrolled={isScrolled}
+              />
               <div>
                 <HashtagContainer isScrolled={isScrolled}>
                   {questionData.hashTag.map((keyword, idx) => {
@@ -287,8 +304,8 @@ export default function PostPage({ history, location, match }) {
                   <SkeletonHashTag variant="text" animation="wave" />
                 </HashtagContainer>
                 <StyledHeader>
-                  <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
-                  <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
+                  <SkeletonCard variant="rect" height="2rem" width={350} animation="wave" />
+                  <SkeletonCard variant="rect" height="2rem" width={350} animation="wave" />
                 </StyledHeader>
               </div>
             </HeadingContainer>

--- a/client/src/pages/PostPage/PostPage.js
+++ b/client/src/pages/PostPage/PostPage.js
@@ -16,16 +16,49 @@ import { setError } from 'redux/storage/error/error';
 import { fetchCurrentQuestion } from 'redux/storage/post/post';
 import { fetchCurrentUserData } from 'redux/storage/currentUser/currentUser';
 import badwordFilter from 'utils/badwordFilter/badwordFilter';
+import useScrollDetect from 'hooks/useScrollDetect';
+import getHashTagColor from 'utils/getHashTagColor/getHashTagColor';
 
 /* ---------------------------- styled components --------------------------- */
-const HeadingContainer = styled.span`
+const HeadingContainer = styled.div`
+  z-index: 100;
   background-color: var(--color-body);
   width: 100vw;
   margin-bottom: 3em;
+  position: sticky;
+  top: 4.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 15em;
+  transition: min-height 0.2s ease-out;
+
+  // 스크롤된 상태일때 높이 변화
+  ${({ isScrolled }) =>
+    isScrolled &&
+    css`
+      flex-flow: column;
+      min-height: 5em;
+
+      div {
+        display: flex;
+        align-items: center;
+      }
+    `}
+
+  // 스크롤된 상태 + 화면이 640 보다 작을때 태그가 보이지 않기 때문에 배경화면으로 대체
+  ${({ isScrolled, bgColor }) =>
+    isScrolled &&
+    bgColor &&
+    css`
+      @media screen and (max-width: 640px) {
+        background-color: var(${bgColor});
+      }
+    `};
 
   // 모바일
   @media screen and (max-width: 480px) {
-    min-width: 100vw;
+    min-width: 100%;
   }
 `;
 
@@ -36,6 +69,12 @@ const StyledHeader = styled.h2`
   text-align: center;
   margin: 0 auto;
   padding-bottom: 1.4em;
+  ${({ isScrolled }) =>
+    isScrolled &&
+    css`
+      padding: 0.5em;
+      font-size: 1.4rem;
+    `}
 `;
 
 const HashtagContainer = styled.div`
@@ -43,8 +82,16 @@ const HashtagContainer = styled.div`
   display: flex;
   margin: 2em auto;
   justify-content: space-evenly;
-  > div {
-  }
+
+  ${({ isScrolled }) =>
+    isScrolled &&
+    css`
+      && {
+        @media screen and (max-width: 640px) {
+          display: none;
+        }
+      }
+    `}
 `;
 
 // 💀 skeleton ui
@@ -103,9 +150,8 @@ export default function PostPage({ history, location, match }) {
   const { currentUserData: userData } = useSelector((state) => state.currentUser);
   const [isAnswered, setIsAnswered] = useState(false);
   const [isInputLoading, setIsInputLoading] = useState(false);
-
+  const isScrolled = useScrollDetect();
   const dispatch = useDispatch();
-
   // handlers
   const handleIsAnswered = () => {
     setIsAnswered(true);
@@ -200,21 +246,23 @@ export default function PostPage({ history, location, match }) {
       setIsInputLoading(false);
     };
   }, [dispatch, questionData, qid]);
-
   return (
     <>
       <TextHeaderBar page="home" />
       <PageContainer page="post" variants={pageEffect} initial="hidden" animate="visible">
         {questionData && userData ? (
           <>
-            <HeadingContainer>
-              <HashtagContainer>
-                {questionData.hashTag.map((keyword, idx) => {
-                  return <Hashtag key={idx} type={keyword} />;
-                })}
-              </HashtagContainer>
-              <StyledHeader>{questionData.content}</StyledHeader>
+            <HeadingContainer isScrolled={isScrolled} bgColor={getHashTagColor(questionData?.hashTag[0])}>
+              <div>
+                <HashtagContainer isScrolled={isScrolled}>
+                  {questionData.hashTag.map((keyword, idx) => {
+                    return <Hashtag key={idx} type={keyword} />;
+                  })}
+                </HashtagContainer>
+                <StyledHeader isScrolled={isScrolled}>{questionData.content}</StyledHeader>
+              </div>
             </HeadingContainer>
+
             <Answers
               answersList={questionData.answers}
               userId={userData[0]._id}
@@ -233,15 +281,16 @@ export default function PostPage({ history, location, match }) {
         ) : (
           <>
             <HeadingContainer>
-              <HashtagContainer>
-                <SkeletonHashTag variant="text" animation="wave" />
-                <SkeletonHashTag variant="text" animation="wave" />
-              </HashtagContainer>
-
-              <StyledHeader>
-                <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
-                <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
-              </StyledHeader>
+              <div>
+                <HashtagContainer>
+                  <SkeletonHashTag variant="text" animation="wave" />
+                  <SkeletonHashTag variant="text" animation="wave" />
+                </HashtagContainer>
+                <StyledHeader>
+                  <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
+                  <SkeletonCard variant="rect" height="2rem" width="100%" animation="wave" />
+                </StyledHeader>
+              </div>
             </HeadingContainer>
             <SkeletonAnswer>
               <SkeletonProfile>

--- a/client/src/utils/getHashTagColor/getHashTagColor.js
+++ b/client/src/utils/getHashTagColor/getHashTagColor.js
@@ -1,0 +1,37 @@
+const getHashTagColor = (type) => {
+  let theme = '';
+  switch (type) {
+    case 'All':
+      theme = '--color-text';
+      break;
+    case 'CSS':
+      theme = '--color-blue1';
+      break;
+    case 'JavaScript':
+      theme = '--color-yellow';
+      break;
+    case 'OS':
+      theme = '--color-green1';
+      break;
+    case 'Database':
+      theme = '--color-purple';
+      break;
+    case 'Network':
+      theme = '--color-blue2';
+      break;
+    case 'Front-End':
+      theme = '--color-green2';
+      break;
+    case 'Back-End':
+      theme = '--color-orange2';
+      break;
+    case 'ETC':
+      theme = '--color-gray2';
+      break;
+    default:
+      break;
+  }
+  return theme;
+};
+
+export default getHashTagColor;


### PR DESCRIPTION
## 개요

- 포스트 페이지 개선 및 스크롤 이펙트 추가

## 작업사항

- 뒤로가기 버튼 추가
- 누락된 Scroll Top 버튼 추가 + 스크롤을 조금이라도 했을시 버튼이 보이도록 수정
- 커스텀 useScrollDetect 훅 추가 (45px 만큼 스크롤 됐을시 질문 헤더 크기가 줄면서 상단에 계속 고정되어있도록 구현) 
- 모바일 환경에서도 겹치지 않도록 레이아웃 수정
- 해시태그 색깔을 받아올수있게 util 함수 작성 (기존 hashtag에 있던 switch case 문을 util함수로 리팩토링)
- ad배너 깃헙주소 -> 배포 주소 교체

## 스크린샷/GIF

**화면 > 640px** (데스크탑)

_태그 1개_
![scroll1](https://user-images.githubusercontent.com/40879385/117573252-cbff5200-b111-11eb-9d08-e5fca1ce47c0.gif)

_태그 2개_
![scoll6](https://user-images.githubusercontent.com/40879385/117573420-a9ba0400-b112-11eb-8824-2f81983f54e4.gif)


**화면 < 640px** (테블릿) - 태그가 보이지 않지만 태그 색깔이 적용됨 (태그가 여러개일시 첫번째 적용)

_자바스크립트 태그_

![scroll2](https://user-images.githubusercontent.com/40879385/117573292-01a43b00-b112-11eb-9279-dbf2c00cb8eb.gif)

_백엔드 태그_

![scroll4](https://user-images.githubusercontent.com/40879385/117573372-6c557680-b112-11eb-95ac-8c6d693eaa38.gif)

_CSS + 프론트엔드 태그 (CSS 태그 색깔로 적용)_

![scroll5](https://user-images.githubusercontent.com/40879385/117573466-061d2380-b113-11eb-86ef-1e8d87a19b1d.gif)



**화면 < 480px** (모바일) - 뒤로가기 버튼 위치 변경
![scroll3](https://user-images.githubusercontent.com/40879385/117573333-3fa15f00-b112-11eb-9a8c-0ff523a8e2fb.gif)





